### PR TITLE
Bump proof serialization format version

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -69,7 +69,7 @@ mod proof_format {
     pub const MAGIC: &[u8] = b"NPOR";
 
     /// Current format version for forward compatibility
-    pub const VERSION: u16 = 1;
+    pub const VERSION: u16 = 2;
 
     /// Header size in bytes: magic(4) + version(2) + length(4)
     pub const HEADER_SIZE: usize = 10;

--- a/tests/api_functionality.rs
+++ b/tests/api_functionality.rs
@@ -196,7 +196,7 @@ fn test_proof_serialization_format_validation() {
     assert!(result.is_err(), "Should reject unsupported version");
 
     // Test truncated data
-    let truncated = b"NPOR\x01\x00";
+    let truncated = b"NPOR\x02\x00";
     let result = Proof::from_bytes(truncated);
     assert!(result.is_err(), "Should reject truncated data");
 
@@ -211,7 +211,7 @@ fn test_proof_serialization_rejects_oversized_payload_length() {
     let oversized_len = (config::MAX_PROOF_SIZE_BYTES + 1) as u32;
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"NPOR"); // magic
-    bytes.extend_from_slice(&1u16.to_le_bytes()); // version
+    bytes.extend_from_slice(&2u16.to_le_bytes()); // version
     bytes.extend_from_slice(&oversized_len.to_le_bytes()); // declared payload size
                                                            // No payload bytes appended: parser should reject on size bound first.
 


### PR DESCRIPTION
Bump proof wire-format VERSION to reflect compatibility changes introduced in PR #26.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-the-wire `Proof` serialization header version and updates validation tests, which can break interoperability with clients still producing/expecting v1 proofs.
> 
> **Overview**
> Bumps the `Proof` wire-format header `VERSION` from `1` to `2`, so newly serialized proofs advertise the updated format and `from_bytes` rejects the prior version.
> 
> Updates serialization/validation tests to use the new version when constructing truncated/oversized headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a9db50aa8f633ad066c7f1e4fe8605814ff43b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->