### PR TITLE
Arity assert message

### DIFF
--- a/src/circuit/synth.rs
+++ b/src/circuit/synth.rs
@@ -40,9 +40,10 @@ pub fn synthesize_por_circuit<F: PrimeField + PrimeFieldBits, CS: ConstraintSyst
     assert_eq!(
         z.len(),
         layout.arity(),
-        "Public input count mismatch: expected {} (FIXED={} + ledger_indices={} + depths={} + seeds={} + leaves={}), got {}",
+        "Public input count mismatch: expected {} (FIXED={} + ledger_indices={} + depths={} + seeds={} + expected_rcs={} + leaves={}), got {}",
         layout.arity(),
         config::PublicIOLayout::FIXED,
+        files_per_step,
         files_per_step,
         files_per_step,
         files_per_step,


### PR DESCRIPTION
Update `assert_eq!` message in `synth.rs` to correctly reflect all `PublicIOLayout` sections, preventing confusing breakdown mismatches on assertion failure.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `assert_eq!` failure message for public input arity, with no functional or constraint changes.
> 
> **Overview**
> Fixes the public-input arity assertion message in `src/circuit/synth.rs` to correctly include the `expected_rcs` section in the breakdown (and its per-file count), so any arity mismatch error reports an accurate component summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faccd6a9fbe6793ca9939d6ab9b80879f6c8e1bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->