### PR TITLE
Make proofs constant-size and stabilize ledger indices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "picus-2"]
 
 permissions:
   contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "kontor-crypto"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kontor-crypto"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 default-run = "kontor-crypto"
 license = "MIT"

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -50,11 +50,10 @@ sequenceDiagram
     Prover->>Prover: Select a set of Open Challenges to answer
     Prover->>Prover: Fetch corresponding PreparedFiles
     Prover->>Prover: PorSystem.prove(files, challenges) → Proof
-    Note over Prover: Proof object internally contains challenge_ids
+    Note over Prover: Proof object carries compressed SNARK + ledger_root + aggregated_tree_depth
 
     Prover-->>Verifier: Broadcast Proof to the network
-    Verifier->>Verifier: On receiving Proof, extract challenge_ids
-    Verifier->>Verifier: Fetch full Challenge objects from local database by ID
+    Verifier->>Verifier: On receiving Proof, look up the claimed Challenge set out-of-band
     Verifier->>Verifier: PorSystem.verify(proof, challenges) → bool
     alt is valid
         Verifier->>Verifier: Mark covered Open challenges as Resolved
@@ -66,13 +65,14 @@ sequenceDiagram
 ## Ledger & Aggregation
 
 -   A `FileLedger` binds the set of files via an aggregated Merkle tree built over root commitments `rc = H(TAG_RC, root, depth)`.
--   Files are ordered canonically by `file_id` (lexicographic, e.g., `BTreeMap` order). Public ledger indices refer to this canonical ordering.
+-   Files are committed at explicit stable append-only ledger indices. The `files` map is key-sorted for lookup, but the aggregated tree is built by `ledger_index`, not lexicographic `file_id` order.
 -   Multi-file proofs pin the ledger root as the aggregated root; single-file proofs pin the file root.
--   The verifier provides public ledger indices; the circuit trusts these (no range checks in circuit).
+-   The verifier re-derives public ledger indices from its own ledger state and rejects statements whose derived indices do not fit the claimed aggregated tree depth.
 
 ## Determinism & Canonical Ordering
 
--   Any set of files is treated deterministically by sorting by `file_id` whenever an order is required.
+-   Challenge sets are ordered canonically by `(file_id, challenge_id)` when a proof statement is built.
+-   Ledger reconstruction is deterministic only when explicit stable indices are preserved.
 -   The map from `file_id` → `PreparedFile` is derived internally from `Vec<PreparedFile>` to avoid user ordering mistakes.
 -   Seeds differ per file; domain separation prevents cross-file bias (multi-batch aggregation supported).
 
@@ -82,7 +82,9 @@ sequenceDiagram
 // Public commitment to a file
 pub struct FileMetadata {
     pub root: FieldElement,
-    pub file_id: String,            // hex(SHA256(data))
+    pub object_id: String,          // obj_<SHA256(data)>
+    pub file_id: String,            // file_<SHA256(domain || len(data) || data || len(nonce) || nonce)>
+    pub nonce: Vec<u8>,             // upload-specific nonce used in file_id derivation
     pub padded_len: usize,          // Total Merkle leaves (power of 2)
     pub original_size: usize,       // Original file size in bytes
     pub filename: String,
@@ -110,14 +112,25 @@ pub struct Challenge {
 // Deterministic identity for a Challenge.
 pub struct ChallengeID([u8; 32]);
 
-// Final succinct proof that includes its coverage set.
+// Final succinct proof with constant-size metadata.
 pub struct Proof {
     // existing CompressedSNARK payload
-    pub challenge_ids: Vec<ChallengeID>, // Exact ordered set of challenges covered
+    pub ledger_root: FieldElement,
+    pub aggregated_tree_depth: usize,
 }
 
 // Derivation for ChallengeID (using stable, cryptographic fields only)
-challenge_id = H(TAG_CHALLENGE_ID, encode(block_height) || encode(seed) || encode(file_id) || encode(root) || encode(depth) || encode(num_challenges) || [encode(prover_id)])
+challenge_id =
+    H(TAG_CHALLENGE_ID
+      || encode(block_height)
+      || encode(seed)
+      || len(file_id) || file_id
+      || len(nonce) || nonce
+      || encode(padded_len)
+      || encode(original_size)
+      || encode(root)
+      || encode(num_challenges)
+      || len(prover_id) || prover_id)
 ```
 
 ## Proof Serialization
@@ -129,11 +142,11 @@ let bytes = proof.to_bytes()?;
 let parsed = Proof::from_bytes(&bytes)?;
 ```
 
-The format is versioned, includes the `challenge_ids` vector, and rejects any trailing data.
+The format is versioned, rejects trailing data, and no longer serializes dynamic `challenge_ids` or `ledger_indices` vectors.
 
 ### Encoding Notes
 
 - Use a network-canonical encoding with explicit versioning and magic bytes.
 - Fixed-width, little-endian encodings for integers (e.g., `block_height: u64`).
 - Field elements are encoded in a canonical 32-byte form.
-- `challenge_ids` are serialized as a length-prefixed vector of 32-byte IDs.
+- Challenge coverage is supplied out-of-band to the verifier and rebound through verifier-constructed public inputs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Kontor-Crypto implements Proof-of-Retrievability using recursive SNARKs. Storage
 
 ### 3. Public Input Construction (`src/api/plan.rs`, `src/api/prove.rs`, `src/api/verify.rs`)
 
-`Plan::make_plan()` and `build_z0_primary()` bind proofs to specific files and ledger state. Public I/O layout in `src/config.rs::PublicIOLayout` (lines 46-181). Verify prover/verifier construct identical inputs, aggregated root derived from verifier's ledger only, canonical ordering, no prover-controlled values.
+`Plan::make_plan()` and `build_z0_primary()` bind proofs to specific files and ledger state. Public I/O layout in `src/config.rs::PublicIOLayout` (lines 46-181). Verify prover/verifier construct identical inputs, aggregated root derived from verifier's ledger only, challenge ordering is canonical, and ledger indices are verifier-derived rather than prover-controlled.
 
 ### 4. Ledger Root Pinning (`src/api/plan.rs` lines 46-52)
 
@@ -22,7 +22,7 @@ Single-file proofs use file root from metadata; multi-file uses `ledger.tree.roo
 
 ### 5. Proof Verification (`src/api/verify.rs`)
 
-`verify()` performs validation before SNARK verification. Check error vs invalid proof distinction (`Ok(false)` vs `Err`), no panics on malformed input, challenge ID binding.
+`verify()` performs validation before SNARK verification. Check error vs invalid proof distinction (`Ok(false)` vs `Err`), no panics on malformed input, and challenge-set binding via verifier-constructed public inputs.
 
 ### 6. Serialization (`src/api/types.rs`)
 
@@ -58,49 +58,59 @@ Verify version pinning, security advisories, no known vulnerabilities, component
 
 # Input Validation
 
-| Function | Inputs | DoS Risk | Handled |
-|----------|--------|----------|---------|
-| `prepare_file()` | data size, filename | Large files | ✅ |
-| `Challenge::new()` | num_challenges, prover_id | Extreme values | ✅ |
-| `prove()` | challenges.len(), num_challenges | Resource exhaustion | ✅ |
-| `verify()` | proof bytes, challenges | Malformed data | ✅ |
-| `reconstruct_file()` | sector count, metadata | Invalid combinations | ✅ |
-| `FileLedger::load()` | file size, contents | Large/malformed files | ✅ |
+| Function             | Inputs                           | DoS Risk              | Handled |
+| -------------------- | -------------------------------- | --------------------- | ------- |
+| `prepare_file()`     | data size, filename              | Large files           | ✅      |
+| `Challenge::new()`   | num_challenges, prover_id        | Extreme values        | ✅      |
+| `prove()`            | challenges.len(), num_challenges | Resource exhaustion   | ✅      |
+| `verify()`           | proof bytes, challenges          | Malformed data        | ✅      |
+| `reconstruct_file()` | sector count, metadata           | Invalid combinations  | ✅      |
+| `FileLedger::load()` | file size, contents              | Large/malformed files | ✅      |
 
 **Boundary conditions:** empty inputs, maximum sizes (file/challenge/ledger count), zero values (depth, size, count), type boundaries (usize::MAX, u64::MAX).
 
 ## Security Properties
 
 ### Soundness
+
 Prover cannot generate valid proof without data. Check circuit constraints (`synth.rs`), Merkle path validation, state chaining (prevents step skipping), no freely-chosen witness values. Tests: `security_malicious_prover.rs` (9).
 
 ### Completeness
+
 Honest prover always succeeds. Review error paths in `prove()`, witness generation for valid cases, no false rejections. Tests: all e2e.
 
 ### Binding
-Proof bound to specific challenges and ledger. Public inputs include aggregated_root (from ledger), challenge IDs derived deterministically (includes prover_id), verified before SNARK check, state chain creates temporal binding. Tests: `security_replay_attack.rs`, `security_ledger_root_pinning.rs`.
+
+Proof bound to specific challenges and ledger once the verifier supplies the intended `Challenge` set. Public inputs include aggregated_root (from ledger), verifier-derived ledger indices, deterministically derived challenge-set state (includes prover_id through `Challenge::id()`), and the recursive state chain. Tests: `security_replay_attack.rs`, `security_ledger_root_pinning.rs`.
 
 ### Determinism
-Same inputs → same outputs. No randomness, canonical ordering (BTreeMap), fixed serialization. Tests: `regression.rs`, `api_consistency.rs`.
+
+Same inputs → same outputs. No randomness, canonical challenge ordering, explicit stable ledger indices for reconstruction, fixed serialization. Tests: `regression.rs`, `api_consistency.rs`.
 
 ## Attack Vectors
 
 ### Malformed Proof Bytes (`Proof::from_bytes()`)
+
 Parser vulnerabilities, buffer overflows. Mitigations: magic byte validation, length checks, trailing data rejection, version validation.
 
 ### Resource Exhaustion (`prove()`, parameter generation)
+
 Memory exhaustion, DoS. Limits: MAX_NUM_CHALLENGES (10,000), PRACTICAL_MAX_FILES (1,024), parameter cache (50), no unbounded loops.
 
 ### Integer Overflow (sector calculations, index arithmetic)
+
 Checked arithmetic, documented type conversions, bounds enforced before casts.
 
 ### Depth/Metadata Tampering (challenge construction, verification)
+
 Root commitment binds (root, depth): `rc = H(TAG_RC, root, depth)`. Public depth in circuit, ledger lookup uses rc, gating prevents depth=0 abuse.
 
 ### Ledger Substitution (multi-file verification)
+
 Verifier derives aggregated root from its own ledger, not prover-supplied, cryptographically bound via public inputs.
 
 ### State Chain Manipulation (recursive proving)
+
 State evolution one-way: `state_new = H(TAG_STATE_UPDATE, state_old, leaf)`. Circuit enforces state threading, no skipping/reordering.
 
 ## Test Coverage
@@ -148,11 +158,11 @@ Verifier generates parameters from challenge shape independently. If prover used
 
 ## Dependencies
 
-| Dependency | Version | Role | Audit Status |
-|------------|---------|------|--------------|
-| `nova-snark` | 0.41.0 | Nova SNARK & Poseidon hash | Microsoft Research |
-| `reed-solomon-erasure` | 6.0.0 | Erasure coding | ? |
-| `ff` | 0.13 | Finite field arithmetic | ? |
+| Dependency             | Version | Role                       | Audit Status       |
+| ---------------------- | ------- | -------------------------- | ------------------ |
+| `nova-snark`           | 0.41.0  | Nova SNARK & Poseidon hash | Microsoft Research |
+| `reed-solomon-erasure` | 6.0.0   | Erasure coding             | ?                  |
+| `ff`                   | 0.13    | Finite field arithmetic    | ?                  |
 
 # Pre-Audit Checklist
 

--- a/src/api/prove.rs
+++ b/src/api/prove.rs
@@ -67,14 +67,9 @@ pub fn prove(
     let compressed_snark = CompressedSNARK::prove(&params.pp, &params.keys.pk, &recursive_snark)
         .map_err(|e| KontorPoRError::Snark(format!("Proof compression failed: {e:?}")))?;
 
-    // Collect challenge IDs in order
-    let challenge_ids: Vec<super::types::ChallengeID> = challenges.iter().map(|c| c.id()).collect();
-
     Ok(super::types::Proof {
         compressed_snark,
-        challenge_ids,
         ledger_root: plan.aggregated_root,
-        ledger_indices: plan.ledger_indices.clone(),
         aggregated_tree_depth: plan.aggregated_tree_depth,
     })
 }

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -100,6 +100,8 @@ impl<'a> PorSystem<'a> {
     /// Verify a proof against the Challenges it claims to answer.
     ///
     /// This method validates challenge inputs and performs SNARK verification.
+    /// The proof bytes are not self-describing coverage metadata; callers must supply
+    /// the exact `Challenge` objects they intend this proof to satisfy.
     ///
     /// # Arguments
     ///

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -7,7 +7,6 @@
 use super::types::{Challenge, FileMetadata, PreparedFile, Proof};
 use crate::{ledger::FileLedger, KontorPoRError, Result};
 use std::collections::BTreeMap;
-use std::collections::HashSet;
 use tracing::debug;
 
 /// The unified API entry point for the Nova-based Proof-of-Retrievability system.
@@ -65,7 +64,7 @@ impl<'a> PorSystem<'a> {
     ///
     /// # Returns
     ///
-    /// Returns a Proof containing the compressed SNARK and the challenge IDs
+    /// Returns a Proof containing the compressed SNARK and constant-size metadata.
     pub fn prove(&self, files: Vec<&PreparedFile>, challenges: &[Challenge]) -> Result<Proof> {
         // Convert Vec<&PreparedFile> to BTreeMap<String, &PreparedFile>
         let mut files_map = BTreeMap::new();
@@ -100,8 +99,7 @@ impl<'a> PorSystem<'a> {
 
     /// Verify a proof against the Challenges it claims to answer.
     ///
-    /// This method validates that the proof's challenge_ids exactly match
-    /// the provided challenges and then performs SNARK verification.
+    /// This method validates challenge inputs and performs SNARK verification.
     ///
     /// # Arguments
     ///
@@ -116,44 +114,8 @@ impl<'a> PorSystem<'a> {
         for challenge in challenges {
             challenge.validate()?;
         }
-
-        let mut seen = HashSet::with_capacity(challenges.len());
-        for challenge in challenges {
-            if !seen.insert(challenge.id()) {
-                return Err(KontorPoRError::InvalidInput(
-                    "verify: duplicate challenge detected".to_string(),
-                ));
-            }
-        }
-
-        // Validate that proof.challenge_ids matches the provided challenges
-        let expected_ids: Vec<_> = challenges.iter().map(|c| c.id()).collect();
-
-        if proof.challenge_ids.len() != expected_ids.len() {
-            return Err(KontorPoRError::InvalidInput(format!(
-                "Challenge count mismatch: proof covers {} challenges, provided {}",
-                proof.challenge_ids.len(),
-                expected_ids.len()
-            )));
-        }
-
-        // Check that all challenge IDs match (order matters for Nova)
-        for (i, (proof_id, expected_id)) in proof
-            .challenge_ids
-            .iter()
-            .zip(expected_ids.iter())
-            .enumerate()
-        {
-            if proof_id != expected_id {
-                return Err(KontorPoRError::InvalidInput(format!(
-                    "Challenge ID mismatch at position {}: proof has {:?}, expected {:?}",
-                    i, proof_id.0, expected_id.0
-                )));
-            }
-        }
-
         debug!(
-            "PorSystem::verify - validated {} challenge IDs",
+            "PorSystem::verify - verifying {} challenges",
             challenges.len()
         );
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -41,23 +41,11 @@ pub struct ChallengeID(pub [u8; 32]);
 pub struct Proof {
     /// The compressed SNARK proof
     pub compressed_snark: CompressedSNARK<E1, E2, C, S1, S2>,
-    /// Exact ordered set of challenges covered by this proof
-    pub challenge_ids: Vec<ChallengeID>,
     /// The ledger root used during proof generation.
     /// Verifiers must validate this root is in their accepted historical roots set
     /// before verification. This enables cross-block aggregation without requiring
     /// provers to regenerate proofs when new files activate.
     pub ledger_root: FieldElement,
-    /// The ledger indices for each file at proof generation time.
-    /// These are the positions of each file's root commitment (rc) in the ledger tree.
-    ///
-    /// Important: indices are *relative to the ledger_root*. Adding files can change
-    /// canonical positions in later ledger states (because ordering is by file_id),
-    /// so verifiers must use the indices bundled in the proof together with the
-    /// proof's ledger_root.
-    ///
-    /// The SNARK proves these indices are correct for the claimed ledger_root.
-    pub ledger_indices: Vec<usize>,
     /// The aggregated tree depth at proof generation time.
     /// Required for verification to load the correct circuit parameters.
     pub aggregated_tree_depth: usize,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -56,8 +56,12 @@ mod proof_format {
     /// Magic bytes identifying Nova PoR proof format
     pub const MAGIC: &[u8] = b"NPOR";
 
-    /// Current format version for forward compatibility
-    pub const VERSION: u16 = 2;
+    /// Current format version for forward compatibility.
+    ///
+    /// Version 3 removes the serialized `challenge_ids` and `ledger_indices`
+    /// vectors from `Proof`, so older version-2 payloads must not decode as if
+    /// they were the new constant-size proof format.
+    pub const VERSION: u16 = 3;
 
     /// Header size in bytes: magic(4) + version(2) + length(4)
     pub const HEADER_SIZE: usize = 10;

--- a/src/api/verify.rs
+++ b/src/api/verify.rs
@@ -23,9 +23,9 @@ use tracing::{debug, info_span};
 /// aggregation: proofs generated against older ledger states remain valid as long as
 /// the root is in the historical set.
 ///
-/// The proof includes the ledger indices at proof generation time. The SNARK proves
-/// these indices are correct for the claimed root, so the verifier doesn't need to
-/// recompute them from the current ledger state.
+    /// The proof does not carry prover-supplied ledger indices. The verifier derives the
+    /// canonical ledger indices from protocol/ledger state and supplies them as public inputs,
+    /// binding the SNARK statement to the verifier's notion of which files are being challenged.
 ///
 /// For single-file proofs (k = 1), the ledger root check is skipped because the circuit
 /// uses the file's Merkle root directly instead of the ledger root.
@@ -41,7 +41,7 @@ use tracing::{debug, info_span};
 /// # Arguments
 ///
 /// * `challenges` - Vector of challenges to verify against
-/// * `proof` - The proof to verify (includes ledger_root and ledger_indices)
+/// * `proof` - The proof to verify (includes ledger_root and aggregated_tree_depth)
 /// * `ledger` - The file ledger (used for historical root validation, not index computation)
 ///
 /// # Returns

--- a/src/api/verify.rs
+++ b/src/api/verify.rs
@@ -23,9 +23,9 @@ use tracing::{debug, info_span};
 /// aggregation: proofs generated against older ledger states remain valid as long as
 /// the root is in the historical set.
 ///
-    /// The proof does not carry prover-supplied ledger indices. The verifier derives the
-    /// canonical ledger indices from protocol/ledger state and supplies them as public inputs,
-    /// binding the SNARK statement to the verifier's notion of which files are being challenged.
+/// The proof does not carry prover-supplied ledger indices. The verifier derives the
+/// canonical ledger indices from protocol/ledger state and supplies them as public inputs,
+/// binding the SNARK statement to the verifier's notion of which files are being challenged.
 ///
 /// For single-file proofs (k = 1), the ledger root check is skipped because the circuit
 /// uses the file's Merkle root directly instead of the ledger root.

--- a/src/api/verify.rs
+++ b/src/api/verify.rs
@@ -80,21 +80,6 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
         }
     }
 
-    // Bind proof to the exact challenge set (including non-circuit fields such as
-    // block_height/prover_id) so callers of verify_raw() cannot bypass this check.
-    let expected_ids: Vec<_> = challenges.iter().map(|c| c.id()).collect();
-    if proof.challenge_ids.len() != expected_ids.len() {
-        return Ok(false);
-    }
-    if proof
-        .challenge_ids
-        .iter()
-        .zip(expected_ids.iter())
-        .any(|(a, b)| a != b)
-    {
-        return Ok(false);
-    }
-
     // Create unified preprocessing plan (derives root internally for security)
     let plan = Plan::make_plan(challenges, ledger)?;
 
@@ -118,14 +103,6 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
         ));
     }
 
-    if proof.ledger_indices.len() != plan.files_per_step {
-        return Err(KontorPoRError::InvalidInput(format!(
-            "Proof ledger_indices length {} does not match circuit files_per_step {}",
-            proof.ledger_indices.len(),
-            plan.files_per_step
-        )));
-    }
-
     if is_multi_file {
         let max_leaf_count = 1usize
             .checked_shl(proof.aggregated_tree_depth as u32)
@@ -136,10 +113,10 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
                 ))
             })?;
 
-        for (i, idx) in proof.ledger_indices.iter().enumerate() {
+        for (i, idx) in plan.ledger_indices.iter().enumerate() {
             if *idx >= max_leaf_count {
                 return Err(KontorPoRError::InvalidInput(format!(
-                    "Proof ledger_indices[{}] = {} is out of range for aggregated_tree_depth {} (max {})",
+                    "Derived ledger_indices[{}] = {} is out of range for aggregated_tree_depth {} (max {})",
                     i,
                     idx,
                     proof.aggregated_tree_depth,
@@ -212,19 +189,17 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
         }
     }
 
-    // Build public inputs using:
-    // - proof.ledger_root and proof.ledger_indices (from proof, enables historical validation)
-    // - depths and seeds from plan (derived from challenges)
-    debug!("Verify: building z0_primary from proof + challenges");
+    // Build public inputs using verifier-derived indices, depths, seeds, and expected_rcs.
+    debug!("Verify: building z0_primary from proof root + derived challenge inputs");
     debug!("  - Using proof.ledger_root: {:?}", proof.ledger_root);
-    debug!("  - Using proof.ledger_indices: {:?}", proof.ledger_indices);
+    debug!("  - Derived ledger_indices: {:?}", plan.ledger_indices);
     debug!("  - Depths from challenges: {:?}", plan.depths);
 
-    // Build z0_primary with proof's values for root/indices
+    // Build z0_primary with proof's root and verifier-derived indices.
     let z0_primary = plan.public_io_layout.build_z0_primary(
         proof.ledger_root,
         plan.initial_state,
-        &proof.ledger_indices,
+        &plan.ledger_indices,
         &plan.depths,
         &plan.seeds,
         &plan.expected_rcs,
@@ -246,7 +221,7 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
     debug!("  - Number of iterations to verify: {}", num_iterations);
     debug!("  - z0_primary[0] aggregated_root: {:?}", proof.ledger_root);
     debug!("  - z0_primary[1] initial_state: {:?}", plan.initial_state);
-    for (i, idx) in proof.ledger_indices.iter().enumerate() {
+    for (i, idx) in plan.ledger_indices.iter().enumerate() {
         debug!("  - z0_primary[{}] ledger_index_{}: {}", 2 + i, i, idx);
     }
     for (i, depth) in plan.depths.iter().enumerate() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,7 +310,7 @@ pub const MAX_NONCE_LEN_BYTES: usize = 4096;
 pub const DEFAULT_MAX_HISTORICAL_ROOTS: usize = 4096;
 
 /// Current ledger format version
-pub const LEDGER_FORMAT_VERSION: u16 = 1;
+pub const LEDGER_FORMAT_VERSION: u16 = 2;
 
 // --- Test-related Constants ---
 

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -6,14 +6,11 @@
 //!
 //! ## Canonical Index Ordering
 //!
-//! **INVARIANT**: Canonical file indices are determined by lexicographic ordering
-//! of file identifiers in the `BTreeMap`. This ensures deterministic, stable indices:
-//! - Index 0 = first file in lexicographic order
-//! - Index i = i-th file in sorted key order
-//! - Indices remain stable as long as files aren't removed
+//! **INVARIANT**: Canonical file indices are explicit, stable, append-only ledger indices.
+//! A file's index does not change when new files are added.
 //!
-//! The aggregated tree is built from rc values in this same key order, ensuring
-//! that `get_canonical_index_for_rc()` returns the correct tree position.
+//! The aggregated tree is built from rc values ordered by `ledger_index`, padded with zeros
+//! for any missing slots. This keeps verifier-side index derivation deterministic.
 
 use crate::merkle::{build_tree_from_leaves, get_padded_proof_for_leaf, MerkleTree, F};
 use crate::poseidon::calculate_root_commitment;
@@ -21,7 +18,7 @@ use crate::KontorPoRError;
 use bincode::Options;
 use ff::Field;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 
@@ -36,6 +33,12 @@ pub trait FileDescriptor {
     fn root(&self) -> F;
     /// Returns the depth of this file's Merkle tree.
     fn depth(&self) -> usize;
+    /// Returns this file's stable ledger index if known.
+    ///
+    /// Implementations that do not supply an index use append-only assignment.
+    fn ledger_index(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Retention policy for historical roots used during proof validation.
@@ -64,6 +67,15 @@ pub struct FileLedgerEntry {
     pub rc: F,
 }
 
+/// Entry with explicit stable ledger index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexedFileLedgerEntry {
+    /// Stable append-only ledger index for this file.
+    pub ledger_index: usize,
+    /// File commitment data.
+    pub entry: FileLedgerEntry,
+}
+
 impl<T: FileDescriptor> From<&T> for FileLedgerEntry {
     fn from(entry: &T) -> Self {
         let rc = calculate_root_commitment(entry.root(), F::from(entry.depth() as u64));
@@ -81,7 +93,7 @@ struct LedgerData {
     /// Format version for forward compatibility
     version: u16,
     /// The actual ledger data (unified file entries)
-    files: BTreeMap<String, FileLedgerEntry>,
+    files: BTreeMap<String, IndexedFileLedgerEntry>,
     /// Stored root for validation on load
     root: F,
     #[serde(default)]
@@ -108,7 +120,7 @@ struct LedgerData {
 pub struct FileLedger {
     /// Unified map from file identifier to complete file information.
     /// BTreeMap ensures deterministic ordering for canonical ledger construction.
-    pub files: BTreeMap<String, FileLedgerEntry>,
+    pub files: BTreeMap<String, IndexedFileLedgerEntry>,
     /// The aggregated Merkle tree built from rc values (not raw roots).
     #[serde(skip)]
     pub tree: MerkleTree,
@@ -124,6 +136,12 @@ pub struct FileLedger {
     /// Historical-root retention policy.
     #[serde(default)]
     pub historical_root_policy: HistoricalRootPolicy,
+    /// Runtime cache: ledger index -> file_id, used for O(1) uniqueness checks.
+    #[serde(skip)]
+    index_to_file_id: HashMap<usize, String>,
+    /// Runtime cache: next append-only ledger index.
+    #[serde(skip)]
+    next_ledger_index: usize,
 }
 
 impl Default for FileLedger {
@@ -135,6 +153,8 @@ impl Default for FileLedger {
             },
             historical_roots: Vec::new(),
             historical_root_policy: HistoricalRootPolicy::default(),
+            index_to_file_id: HashMap::new(),
+            next_ledger_index: 0,
         }
     }
 }
@@ -221,9 +241,29 @@ impl FileLedger {
     /// ledger.add_file(&metadata).unwrap();
     /// ```
     pub fn add_file(&mut self, entry: &impl FileDescriptor) -> Result<(), KontorPoRError> {
-        // Insert the new file
-        self.files
-            .insert(entry.file_id().to_string(), FileLedgerEntry::from(entry));
+        self.ensure_runtime_index_cache_initialized()?;
+
+        let file_id = entry.file_id().to_string();
+        let resolved_index = self.resolve_ledger_index(&file_id, entry.ledger_index())?;
+
+        if let Some(owner) = self.index_to_file_id.get(&resolved_index) {
+            if owner != &file_id {
+                return Err(KontorPoRError::InvalidInput(format!(
+                    "Ledger index {} already assigned to file '{}'",
+                    resolved_index, owner
+                )));
+            }
+        }
+
+        self.files.insert(
+            file_id.clone(),
+            IndexedFileLedgerEntry {
+                ledger_index: resolved_index,
+                entry: FileLedgerEntry::from(entry),
+            },
+        );
+        self.index_to_file_id.insert(resolved_index, file_id);
+        self.next_ledger_index = self.next_ledger_index.max(resolved_index.saturating_add(1));
 
         // Rebuild tree
         self.rebuild_tree()?;
@@ -256,9 +296,30 @@ impl FileLedger {
         &mut self,
         files: impl IntoIterator<Item = &'a T>,
     ) -> Result<(), KontorPoRError> {
+        self.ensure_runtime_index_cache_initialized()?;
+
         for entry in files {
-            self.files
-                .insert(entry.file_id().to_string(), FileLedgerEntry::from(entry));
+            let file_id = entry.file_id().to_string();
+            let resolved_index = self.resolve_ledger_index(&file_id, entry.ledger_index())?;
+
+            if let Some(owner) = self.index_to_file_id.get(&resolved_index) {
+                if owner != &file_id {
+                    return Err(KontorPoRError::InvalidInput(format!(
+                        "Ledger index {} already assigned to file '{}'",
+                        resolved_index, owner
+                    )));
+                }
+            }
+
+            self.files.insert(
+                file_id.clone(),
+                IndexedFileLedgerEntry {
+                    ledger_index: resolved_index,
+                    entry: FileLedgerEntry::from(entry),
+                },
+            );
+            self.index_to_file_id.insert(resolved_index, file_id);
+            self.next_ledger_index = self.next_ledger_index.max(resolved_index.saturating_add(1));
         }
 
         self.rebuild_tree()
@@ -268,13 +329,26 @@ impl FileLedger {
     /// The tree is built from rc = Poseidon(TAG_RC, root, depth) for each file,
     /// padded to the next power of two to ensure a fixed depth.
     fn rebuild_tree(&mut self) -> Result<(), KontorPoRError> {
-        // Collect rc values in sorted key order (BTreeMap is deterministic)
-        let rc_values: Vec<F> = self.files.values().map(|entry| entry.rc).collect();
-
-        if rc_values.is_empty() {
+        if self.files.is_empty() {
             // An empty ledger has a tree with a single zero leaf.
             self.tree = build_tree_from_leaves(&[F::ZERO])?;
             return Ok(());
+        }
+
+        let max_index = self
+            .files
+            .values()
+            .map(|entry| entry.ledger_index)
+            .max()
+            .ok_or_else(|| KontorPoRError::LedgerValidation {
+                reason: "Failed to determine max ledger index".to_string(),
+            })?;
+        let leaf_count = max_index
+            .checked_add(1)
+            .ok_or_else(|| KontorPoRError::InvalidInput("Ledger index overflow".to_string()))?;
+        let mut rc_values = vec![F::ZERO; leaf_count];
+        for indexed in self.files.values() {
+            rc_values[indexed.ledger_index] = indexed.entry.rc;
         }
 
         let padded_len = rc_values.len().next_power_of_two();
@@ -285,11 +359,73 @@ impl FileLedger {
         Ok(())
     }
 
+    fn resolve_ledger_index(
+        &self,
+        file_id: &str,
+        requested_index: Option<usize>,
+    ) -> Result<usize, KontorPoRError> {
+        if let Some(existing) = self.files.get(file_id) {
+            if let Some(idx) = requested_index {
+                if idx != existing.ledger_index {
+                    return Err(KontorPoRError::InvalidInput(format!(
+                        "File '{}' already has ledger index {}, got conflicting index {}",
+                        file_id, existing.ledger_index, idx
+                    )));
+                }
+            }
+            return Ok(existing.ledger_index);
+        }
+
+        Ok(requested_index.unwrap_or(self.next_ledger_index))
+    }
+
+    fn ensure_runtime_index_cache_initialized(&mut self) -> Result<(), KontorPoRError> {
+        if self.files.is_empty() {
+            self.index_to_file_id.clear();
+            self.next_ledger_index = 0;
+            return Ok(());
+        }
+
+        if self.index_to_file_id.len() == self.files.len() && self.next_ledger_index > 0 {
+            return Ok(());
+        }
+
+        self.rebuild_runtime_index_cache()
+    }
+
+    fn rebuild_runtime_index_cache(&mut self) -> Result<(), KontorPoRError> {
+        self.index_to_file_id.clear();
+        let mut next = 0usize;
+        for (file_id, entry) in &self.files {
+            if let Some(existing_owner) = self
+                .index_to_file_id
+                .insert(entry.ledger_index, file_id.clone())
+            {
+                return Err(KontorPoRError::LedgerValidation {
+                    reason: format!(
+                        "Duplicate ledger_index {} for files '{}' and '{}'",
+                        entry.ledger_index, existing_owner, file_id
+                    ),
+                });
+            }
+            next = next.max(entry.ledger_index.saturating_add(1));
+        }
+        self.next_ledger_index = next;
+        Ok(())
+    }
+
+    /// Returns the next append-only ledger index that will be assigned.
+    pub fn next_ledger_index(&self) -> usize {
+        self.next_ledger_index
+    }
+
     /// Get the canonical ledger index for a specific rc value.
     /// This allows checking if a file with specific (root, depth) exists in the ledger.
     pub fn get_canonical_index_for_rc(&self, rc: F) -> Option<usize> {
-        // Find position by file_id order (same as rebuild_tree) - BTreeMap iteration is deterministic
-        self.files.values().position(|entry| entry.rc == rc)
+        self.files
+            .values()
+            .find(|entry| entry.entry.rc == rc)
+            .map(|entry| entry.ledger_index)
     }
 
     /// Saves the `FileLedger` to the specified path using bincode serialization.
@@ -372,7 +508,10 @@ impl FileLedger {
             tree: MerkleTree::default(),
             historical_roots: data.historical_roots,
             historical_root_policy: data.historical_root_policy,
+            index_to_file_id: HashMap::new(),
+            next_ledger_index: 0,
         };
+        ledger.rebuild_runtime_index_cache()?;
         ledger.rebuild_tree()?;
         ledger.prune_historical_roots();
 
@@ -391,17 +530,11 @@ impl FileLedger {
     }
 
     /// Looks up a file by its ID and returns its canonical index and leaf value (rc).
-    /// The index is its lexicographical rank among all file IDs in the ledger.
+    /// The index is its stable append-only ledger index.
     pub fn lookup(&self, file_id: &str) -> Option<(usize, F)> {
-        if let Some(entry) = self.files.get(file_id) {
-            // The index is the position in the BTreeMap's sorted keys. O(n) but simple.
-            self.files
-                .keys()
-                .position(|k| k == file_id)
-                .map(|index| (index, entry.rc))
-        } else {
-            None
-        }
+        self.files
+            .get(file_id)
+            .map(|entry| (entry.ledger_index, entry.entry.rc))
     }
 
     /// Returns the Merkle proof of inclusion for a given file ID in the aggregated tree.

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -22,6 +22,13 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 
+/// Max allowed gap between the highest `ledger_index` and the number of files.
+///
+/// This prevents adversarial or corrupted inputs (e.g. during `load`) from forcing the
+/// ledger to allocate a vector sized to an arbitrarily large index while holding only
+/// a small number of files.
+const MAX_LEDGER_INDEX_SPARSITY_GAP: usize = 1024;
+
 /// Trait for types that can be added to a [`FileLedger`].
 ///
 /// This trait decouples the ledger from any specific file metadata type,
@@ -255,6 +262,10 @@ impl FileLedger {
             }
         }
 
+        let previous_entry = self.files.get(&file_id).cloned();
+        let previous_owner = self.index_to_file_id.get(&resolved_index).cloned();
+        let previous_next = self.next_ledger_index;
+
         self.files.insert(
             file_id.clone(),
             IndexedFileLedgerEntry {
@@ -265,8 +276,27 @@ impl FileLedger {
         self.index_to_file_id.insert(resolved_index, file_id);
         self.next_ledger_index = self.next_ledger_index.max(resolved_index.saturating_add(1));
 
-        // Rebuild tree
-        self.rebuild_tree()?;
+        // Rebuild tree (roll back state on error so tree/caches remain consistent).
+        if let Err(err) = self.rebuild_tree() {
+            match previous_entry {
+                Some(old) => {
+                    self.files.insert(entry.file_id().to_string(), old);
+                }
+                None => {
+                    self.files.remove(entry.file_id());
+                }
+            }
+            match previous_owner {
+                Some(owner) => {
+                    self.index_to_file_id.insert(resolved_index, owner);
+                }
+                None => {
+                    self.index_to_file_id.remove(&resolved_index);
+                }
+            }
+            self.next_ledger_index = previous_next;
+            return Err(err);
+        }
 
         // Record the new root as a historical root (every valid state is tracked)
         self.record_current_root();
@@ -298,31 +328,151 @@ impl FileLedger {
     ) -> Result<(), KontorPoRError> {
         self.ensure_runtime_index_cache_initialized()?;
 
+        // Phase 1: validate + compute indices without mutating self (last entry wins).
+        let mut planned: BTreeMap<String, IndexedFileLedgerEntry> = BTreeMap::new();
+        let mut planned_indices: HashMap<usize, String> = HashMap::new();
+        let mut next_index = self.next_ledger_index;
+
         for entry in files {
             let file_id = entry.file_id().to_string();
-            let resolved_index = self.resolve_ledger_index(&file_id, entry.ledger_index())?;
 
-            if let Some(owner) = self.index_to_file_id.get(&resolved_index) {
+            // If the file is already present, its ledger_index is stable.
+            if let Some(existing) = self.files.get(&file_id) {
+                if let Some(requested) = entry.ledger_index() {
+                    if requested != existing.ledger_index {
+                        return Err(KontorPoRError::InvalidInput(format!(
+                            "File '{}' already exists with ledger_index {}, but entry requested {}",
+                            file_id, existing.ledger_index, requested
+                        )));
+                    }
+                }
+
+                let idx = existing.ledger_index;
+                if let Some(owner) = self.index_to_file_id.get(&idx) {
+                    if owner != &file_id {
+                        return Err(KontorPoRError::InvalidInput(format!(
+                            "Ledger index {} already assigned to file '{}'",
+                            idx, owner
+                        )));
+                    }
+                }
+                if let Some(owner) = planned_indices.get(&idx) {
+                    if owner != &file_id {
+                        return Err(KontorPoRError::InvalidInput(format!(
+                            "Ledger index {} already assigned to file '{}' in batch",
+                            idx, owner
+                        )));
+                    }
+                }
+
+                planned.insert(
+                    file_id.clone(),
+                    IndexedFileLedgerEntry {
+                        ledger_index: idx,
+                        entry: FileLedgerEntry::from(entry),
+                    },
+                );
+                planned_indices.insert(idx, file_id);
+                continue;
+            }
+
+            // If the file already appeared earlier in this batch, keep its assigned index.
+            if let Some(existing) = planned.get(&file_id) {
+                planned.insert(
+                    file_id,
+                    IndexedFileLedgerEntry {
+                        ledger_index: existing.ledger_index,
+                        entry: FileLedgerEntry::from(entry),
+                    },
+                );
+                continue;
+            }
+
+            // New file: either honor an explicit index or append at next_index.
+            let idx = match entry.ledger_index() {
+                Some(explicit) => explicit,
+                None => {
+                    let idx = next_index;
+                    next_index = next_index.saturating_add(1);
+                    idx
+                }
+            };
+
+            if let Some(owner) = self.index_to_file_id.get(&idx) {
                 if owner != &file_id {
                     return Err(KontorPoRError::InvalidInput(format!(
                         "Ledger index {} already assigned to file '{}'",
-                        resolved_index, owner
+                        idx, owner
+                    )));
+                }
+            }
+            if let Some(owner) = planned_indices.get(&idx) {
+                if owner != &file_id {
+                    return Err(KontorPoRError::InvalidInput(format!(
+                        "Ledger index {} already assigned to file '{}' in batch",
+                        idx, owner
                     )));
                 }
             }
 
-            self.files.insert(
+            planned.insert(
                 file_id.clone(),
                 IndexedFileLedgerEntry {
-                    ledger_index: resolved_index,
+                    ledger_index: idx,
                     entry: FileLedgerEntry::from(entry),
                 },
             );
-            self.index_to_file_id.insert(resolved_index, file_id);
-            self.next_ledger_index = self.next_ledger_index.max(resolved_index.saturating_add(1));
+            planned_indices.insert(idx, file_id);
+            next_index = next_index.max(idx.saturating_add(1));
         }
 
-        self.rebuild_tree()
+        // Phase 2: apply mutations with rollback on rebuild failure.
+        let previous_next = self.next_ledger_index;
+        let mut previous_files: Vec<(String, Option<IndexedFileLedgerEntry>)> = Vec::new();
+        let mut previous_owners: Vec<(usize, Option<String>)> = Vec::new();
+
+        for (file_id, entry) in planned.iter() {
+            previous_files.push((file_id.clone(), self.files.get(file_id).cloned()));
+            previous_owners.push((
+                entry.ledger_index,
+                self.index_to_file_id.get(&entry.ledger_index).cloned(),
+            ));
+        }
+
+        for (file_id, entry) in planned.into_iter() {
+            self.files.insert(file_id, entry);
+        }
+        for (idx, owner) in planned_indices.into_iter() {
+            self.index_to_file_id.insert(idx, owner);
+        }
+        self.next_ledger_index = next_index;
+
+        if let Err(err) = self.rebuild_tree() {
+            for (file_id, prior) in previous_files {
+                match prior {
+                    Some(old) => {
+                        self.files.insert(file_id, old);
+                    }
+                    None => {
+                        self.files.remove(&file_id);
+                    }
+                }
+            }
+            for (idx, prior) in previous_owners {
+                match prior {
+                    Some(owner) => {
+                        self.index_to_file_id.insert(idx, owner);
+                    }
+                    None => {
+                        self.index_to_file_id.remove(&idx);
+                    }
+                }
+            }
+            self.next_ledger_index = previous_next;
+            return Err(err);
+        }
+
+        Ok(())
     }
 
     /// Rebuilds the aggregated Merkle tree from rc values (root commitments).
@@ -346,6 +496,15 @@ impl FileLedger {
         let leaf_count = max_index
             .checked_add(1)
             .ok_or_else(|| KontorPoRError::InvalidInput("Ledger index overflow".to_string()))?;
+
+        let files_len = self.files.len();
+        if leaf_count > files_len.saturating_add(MAX_LEDGER_INDEX_SPARSITY_GAP) {
+            return Err(KontorPoRError::InvalidInput(format!(
+                "Ledger indices too sparse: max_index={} implies leaf_count={} for only {} files",
+                max_index, leaf_count, files_len
+            )));
+        }
+
         let mut rc_values = vec![F::ZERO; leaf_count];
         for indexed in self.files.values() {
             rc_values[indexed.ledger_index] = indexed.entry.rc;

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -42,7 +42,8 @@ pub trait FileDescriptor {
     fn depth(&self) -> usize;
     /// Returns this file's stable ledger index if known.
     ///
-    /// Implementations that do not supply an index use append-only assignment.
+    /// Implementations supplying persisted/reconstructed data must return `Some(index)`.
+    /// Fresh files appended via [`FileLedger::add_file`] must return `None`.
     fn ledger_index(&self) -> Option<usize> {
         None
     }
@@ -235,6 +236,10 @@ impl FileLedger {
     /// * `entry` - Any type that implements [`FileDescriptor`], providing
     ///   the file's ID, root, and depth.
     ///
+    /// [`Self::add_file`] is append-only: it only accepts fresh files and assigns the
+    /// next stable ledger index internally. Persisted/reconstructed entries must use
+    /// [`Self::add_files`] and provide explicit indices via [`FileDescriptor::ledger_index`].
+    ///
     /// # Example
     ///
     /// ```rust,no_run
@@ -251,7 +256,19 @@ impl FileLedger {
         self.ensure_runtime_index_cache_initialized()?;
 
         let file_id = entry.file_id().to_string();
-        let resolved_index = self.resolve_ledger_index(&file_id, entry.ledger_index())?;
+        if entry.ledger_index().is_some() {
+            return Err(KontorPoRError::InvalidInput(format!(
+                "add_file does not accept explicit ledger_index for file '{}'; use add_files for reconstruction",
+                file_id
+            )));
+        }
+        if self.files.contains_key(&file_id) {
+            return Err(KontorPoRError::InvalidInput(format!(
+                "File '{}' already exists in ledger; file_id is immutable",
+                file_id
+            )));
+        }
+        let resolved_index = self.next_ledger_index;
 
         if let Some(owner) = self.index_to_file_id.get(&resolved_index) {
             if owner != &file_id {
@@ -319,8 +336,11 @@ impl FileLedger {
     ///
     /// # Duplicate Handling
     ///
-    /// If a file with the same `file_id` already exists in the ledger or appears
-    /// multiple times in the batch, the last entry wins.
+    /// [`Self::add_files`] is the persisted/reconstruction path. Every entry must carry
+    /// an explicit stable index via [`FileDescriptor::ledger_index`].
+    ///
+    /// Duplicate `file_id`s are rejected, both against existing ledger contents and within
+    /// the batch itself, since `file_id` is immutable.
     ///
     pub fn add_files<'a, T: FileDescriptor + 'a>(
         &mut self,
@@ -328,91 +348,45 @@ impl FileLedger {
     ) -> Result<(), KontorPoRError> {
         self.ensure_runtime_index_cache_initialized()?;
 
-        // Phase 1: validate + compute indices without mutating self (last entry wins).
+        // Phase 1: validate + compute indices without mutating self.
         let mut planned: BTreeMap<String, IndexedFileLedgerEntry> = BTreeMap::new();
         let mut planned_indices: HashMap<usize, String> = HashMap::new();
         let mut next_index = self.next_ledger_index;
 
         for entry in files {
             let file_id = entry.file_id().to_string();
+            let idx = entry.ledger_index().ok_or_else(|| {
+                KontorPoRError::InvalidInput(format!(
+                    "add_files requires explicit ledger_index for file '{}'",
+                    file_id
+                ))
+            })?;
 
-            // If the file is already present, its ledger_index is stable.
-            if let Some(existing) = self.files.get(&file_id) {
-                if let Some(requested) = entry.ledger_index() {
-                    if requested != existing.ledger_index {
-                        return Err(KontorPoRError::InvalidInput(format!(
-                            "File '{}' already exists with ledger_index {}, but entry requested {}",
-                            file_id, existing.ledger_index, requested
-                        )));
-                    }
-                }
-
-                let idx = existing.ledger_index;
-                if let Some(owner) = self.index_to_file_id.get(&idx) {
-                    if owner != &file_id {
-                        return Err(KontorPoRError::InvalidInput(format!(
-                            "Ledger index {} already assigned to file '{}'",
-                            idx, owner
-                        )));
-                    }
-                }
-                if let Some(owner) = planned_indices.get(&idx) {
-                    if owner != &file_id {
-                        return Err(KontorPoRError::InvalidInput(format!(
-                            "Ledger index {} already assigned to file '{}' in batch",
-                            idx, owner
-                        )));
-                    }
-                }
-
-                planned.insert(
-                    file_id.clone(),
-                    IndexedFileLedgerEntry {
-                        ledger_index: idx,
-                        entry: FileLedgerEntry::from(entry),
-                    },
-                );
-                planned_indices.insert(idx, file_id);
-                continue;
+            if self.files.contains_key(&file_id) {
+                return Err(KontorPoRError::InvalidInput(format!(
+                    "File '{}' already exists in ledger; file_id is immutable",
+                    file_id
+                )));
             }
 
-            // If the file already appeared earlier in this batch, keep its assigned index.
-            if let Some(existing) = planned.get(&file_id) {
-                planned.insert(
-                    file_id,
-                    IndexedFileLedgerEntry {
-                        ledger_index: existing.ledger_index,
-                        entry: FileLedgerEntry::from(entry),
-                    },
-                );
-                continue;
+            if planned.contains_key(&file_id) {
+                return Err(KontorPoRError::InvalidInput(format!(
+                    "Duplicate file '{}' provided in add_files batch",
+                    file_id
+                )));
             }
-
-            // New file: either honor an explicit index or append at next_index.
-            let idx = match entry.ledger_index() {
-                Some(explicit) => explicit,
-                None => {
-                    let idx = next_index;
-                    next_index = next_index.saturating_add(1);
-                    idx
-                }
-            };
 
             if let Some(owner) = self.index_to_file_id.get(&idx) {
-                if owner != &file_id {
-                    return Err(KontorPoRError::InvalidInput(format!(
-                        "Ledger index {} already assigned to file '{}'",
-                        idx, owner
-                    )));
-                }
+                return Err(KontorPoRError::InvalidInput(format!(
+                    "Ledger index {} already assigned to file '{}'",
+                    idx, owner
+                )));
             }
             if let Some(owner) = planned_indices.get(&idx) {
-                if owner != &file_id {
-                    return Err(KontorPoRError::InvalidInput(format!(
-                        "Ledger index {} already assigned to file '{}' in batch",
-                        idx, owner
-                    )));
-                }
+                return Err(KontorPoRError::InvalidInput(format!(
+                    "Ledger index {} already assigned to file '{}' in batch",
+                    idx, owner
+                )));
             }
 
             planned.insert(
@@ -516,26 +490,6 @@ impl FileLedger {
 
         self.tree = build_tree_from_leaves(&padded_rcs)?;
         Ok(())
-    }
-
-    fn resolve_ledger_index(
-        &self,
-        file_id: &str,
-        requested_index: Option<usize>,
-    ) -> Result<usize, KontorPoRError> {
-        if let Some(existing) = self.files.get(file_id) {
-            if let Some(idx) = requested_index {
-                if idx != existing.ledger_index {
-                    return Err(KontorPoRError::InvalidInput(format!(
-                        "File '{}' already has ledger index {}, got conflicting index {}",
-                        file_id, existing.ledger_index, idx
-                    )));
-                }
-            }
-            return Ok(existing.ledger_index);
-        }
-
-        Ok(requested_index.unwrap_or(self.next_ledger_index))
     }
 
     fn ensure_runtime_index_cache_initialized(&mut self) -> Result<(), KontorPoRError> {
@@ -688,7 +642,7 @@ impl FileLedger {
         self.tree.layers.len().saturating_sub(1)
     }
 
-    /// Looks up a file by its ID and returns its canonical index and leaf value (rc).
+    /// Looks up a file by its ID and returns its stable ledger index and leaf value (rc).
     /// The index is its stable append-only ledger index.
     pub fn lookup(&self, file_id: &str) -> Option<(usize, F)> {
         self.files

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -111,7 +111,7 @@ struct LedgerData {
 /// ## Historical Root Tracking
 ///
 /// The ledger maintains a set of historical roots for proof validation.
-/// When files are added, the pre-modification root is appended to `historical_roots`.
+/// When files are added, the post-update root is appended to `historical_roots`.
 /// Verifiers check that a proof's `ledger_root` is in this set before accepting it.
 /// This enables cross-block aggregation without proof regeneration.
 ///
@@ -174,8 +174,8 @@ impl FileLedger {
 
     /// Records the current root as a valid historical root.
     ///
-    /// Call this before modifying the ledger (e.g., before adding files) to preserve the
-    /// old root for proof validation.
+    /// The ledger uses this to retain roots that were previously current so that verifiers can
+    /// accept proofs generated against older ledger states (cross-block aggregation).
     pub fn record_current_root(&mut self) {
         use ff::PrimeField;
         let root = self.tree.root();

--- a/tests/api_functionality.rs
+++ b/tests/api_functionality.rs
@@ -200,7 +200,7 @@ fn test_proof_serialization_format_validation() {
     assert!(result.is_err(), "Should reject unsupported version");
 
     // Test truncated data
-    let truncated = b"NPOR\x02\x00";
+    let truncated = b"NPOR\x03\x00";
     let result = Proof::from_bytes(truncated);
     assert!(result.is_err(), "Should reject truncated data");
 
@@ -215,7 +215,7 @@ fn test_proof_serialization_rejects_oversized_payload_length() {
     let oversized_len = (config::MAX_PROOF_SIZE_BYTES + 1) as u32;
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"NPOR"); // magic
-    bytes.extend_from_slice(&2u16.to_le_bytes()); // version
+    bytes.extend_from_slice(&3u16.to_le_bytes()); // version
     bytes.extend_from_slice(&oversized_len.to_le_bytes()); // declared payload size
                                                            // No payload bytes appended: parser should reject on size bound first.
 

--- a/tests/api_functionality.rs
+++ b/tests/api_functionality.rs
@@ -172,10 +172,14 @@ fn test_proof_serialization_roundtrip() {
     let is_valid = system.verify(&deserialized, &[challenge]).unwrap();
     assert!(is_valid, "Deserialized proof should verify successfully");
 
-    // Test that challenge IDs are preserved
+    // Test that proof metadata is preserved
     assert_eq!(
-        proof.challenge_ids, deserialized.challenge_ids,
-        "Challenge IDs should be preserved through serialization"
+        proof.ledger_root, deserialized.ledger_root,
+        "Ledger root should be preserved through serialization"
+    );
+    assert_eq!(
+        proof.aggregated_tree_depth, deserialized.aggregated_tree_depth,
+        "Aggregated tree depth should be preserved through serialization"
     );
 
     println!("  ✓ Proof serialization round-trip successful");
@@ -314,16 +318,11 @@ fn test_porsystem_challenge_id_matching() {
         Challenge::new_test(metadata.clone(), 1000, 2, FieldElement::from(778u64));
     let result = system.verify(&proof, &[different_challenge]);
 
-    match result {
-        Err(kontor_crypto::KontorPoRError::InvalidInput(msg)) => {
-            assert!(
-                msg.contains("Challenge ID mismatch"),
-                "Should report challenge ID mismatch"
-            );
-            println!("  ✓ Challenge ID mismatch correctly detected");
-        }
-        _ => panic!("Expected InvalidInput error for mismatched challenge IDs"),
-    }
+    assert!(
+        matches!(result, Ok(false)),
+        "Mismatched challenge should fail cryptographic verification"
+    );
+    println!("  ✓ Mismatched challenge correctly rejected by SNARK verification");
 }
 
 #[test]

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -11,7 +11,7 @@ use kontor_crypto::{
         PreparedFile,
     },
     config::{self, CHUNK_SIZE_BYTES},
-    ledger::FileLedger,
+    ledger::{FileDescriptor, FileLedger},
     params,
 };
 use rand::rngs::StdRng;
@@ -265,6 +265,49 @@ pub fn synthetic_metadata(file_id: &str, root: FieldElement, depth: usize) -> Fi
         padded_len: 1 << depth,
         original_size: 100,
         filename: format!("{}.dat", file_id),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestFileMetadataRow {
+    pub metadata: FileMetadata,
+    pub ledger_index: usize,
+}
+
+impl TestFileMetadataRow {
+    pub fn new(metadata: FileMetadata, ledger_index: usize) -> Self {
+        Self {
+            metadata,
+            ledger_index,
+        }
+    }
+}
+
+pub fn collect_test_file_metadata_rows(
+    metadatas: impl IntoIterator<Item = FileMetadata>,
+) -> Vec<TestFileMetadataRow> {
+    metadatas
+        .into_iter()
+        .enumerate()
+        .map(|(ledger_index, metadata)| TestFileMetadataRow::new(metadata, ledger_index))
+        .collect()
+}
+
+impl FileDescriptor for TestFileMetadataRow {
+    fn file_id(&self) -> &str {
+        &self.metadata.file_id
+    }
+
+    fn root(&self) -> FieldElement {
+        self.metadata.root
+    }
+
+    fn depth(&self) -> usize {
+        self.metadata.depth()
+    }
+
+    fn ledger_index(&self) -> Option<usize> {
+        Some(self.ledger_index)
     }
 }
 

--- a/tests/ledger_batch_add.rs
+++ b/tests/ledger_batch_add.rs
@@ -8,7 +8,7 @@ use kontor_crypto::api::{self, FieldElement, FileMetadata};
 use kontor_crypto::ledger::FileLedger;
 
 mod common;
-use common::fixtures::synthetic_metadata;
+use common::fixtures::{collect_test_file_metadata_rows, synthetic_metadata, TestFileMetadataRow};
 
 /// Helper to create a dummy FileMetadata for testing.
 /// The depth is derived from padded_len (2^depth).
@@ -34,7 +34,10 @@ fn test_batch_add_basic() {
         dummy_metadata("file_c", 300, 5),
     ];
 
-    ledger.add_files(&files).expect("Batch add should succeed");
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger
+        .add_files(&indexed)
+        .expect("Batch add should succeed");
 
     assert_eq!(ledger.files.len(), 3, "Should have 3 files");
     assert!(ledger.files.contains_key("file_a"));
@@ -52,9 +55,9 @@ fn test_batch_add_empty() {
     let root_before = ledger.tree.root();
 
     // Empty batch should succeed and not change anything
-    let empty: Vec<FileMetadata> = vec![];
+    let indexed_empty: Vec<TestFileMetadataRow> = vec![];
     ledger
-        .add_files(&empty)
+        .add_files(&indexed_empty)
         .expect("Empty batch should succeed");
 
     assert_eq!(ledger.files.len(), 1, "Should still have 1 file");
@@ -66,8 +69,9 @@ fn test_batch_add_single_file() {
     let mut ledger = FileLedger::new();
 
     let files = vec![dummy_metadata("only_file", 999, 5)];
+    let indexed = collect_test_file_metadata_rows(files.clone());
     ledger
-        .add_files(&files)
+        .add_files(&indexed)
         .expect("Single file batch should succeed");
 
     assert_eq!(ledger.files.len(), 1);
@@ -100,7 +104,8 @@ fn test_batch_add_equivalent_to_individual_adds() {
 
     // Method 2: Batch add
     let mut ledger_batch = FileLedger::new();
-    ledger_batch.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger_batch.add_files(&indexed).unwrap();
 
     // Both should produce identical cryptographic results
     assert_eq!(
@@ -131,7 +136,7 @@ fn test_batch_add_equivalent_to_individual_adds() {
 }
 
 #[test]
-fn test_batch_add_order_independence() {
+fn test_batch_add_order_dependence_with_distinct_explicit_indices() {
     // With append-only stable indices, insertion order defines index assignment.
     let files_order1 = vec![
         dummy_metadata("zebra", 1, 3),
@@ -146,10 +151,12 @@ fn test_batch_add_order_independence() {
     ];
 
     let mut ledger1 = FileLedger::new();
-    ledger1.add_files(&files_order1).unwrap();
+    let indexed1 = collect_test_file_metadata_rows(files_order1.clone());
+    ledger1.add_files(&indexed1).unwrap();
 
     let mut ledger2 = FileLedger::new();
-    ledger2.add_files(&files_order2).unwrap();
+    let indexed2 = collect_test_file_metadata_rows(files_order2.clone());
+    ledger2.add_files(&indexed2).unwrap();
 
     assert_ne!(
         ledger1.tree.root(),
@@ -172,35 +179,28 @@ fn test_batch_add_order_independence() {
 // ===========================================
 
 #[test]
-fn test_batch_add_with_duplicates_in_batch() {
+fn test_batch_add_rejects_duplicates_in_batch() {
     let mut ledger = FileLedger::new();
 
-    // Batch contains duplicate file_id - last one should win
+    // Batch contains duplicate file_id entries, which should now be rejected.
     let files = vec![
         dummy_metadata("dup_file", 100, 3),
         dummy_metadata("other_file", 200, 4),
         dummy_metadata("dup_file", 999, 5), // Same file_id, different values
     ];
 
-    ledger.add_files(&files).unwrap();
-
-    assert_eq!(ledger.files.len(), 2, "Should have 2 unique files");
-
-    // The last duplicate should win
-    let dup_entry = ledger.files.get("dup_file").unwrap();
-    assert_eq!(
-        dup_entry.entry.root,
-        FieldElement::from(999u64),
-        "Last duplicate root should be used"
-    );
-    assert_eq!(
-        dup_entry.entry.depth, 5,
-        "Last duplicate depth should be used"
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    let err = ledger
+        .add_files(&indexed)
+        .expect_err("Duplicate file_id should be rejected");
+    assert!(
+        matches!(err, kontor_crypto::KontorPoRError::InvalidInput(_)),
+        "Expected InvalidInput for duplicate file_id, got: {err:?}"
     );
 }
 
 #[test]
-fn test_batch_add_overwrites_existing_files() {
+fn test_batch_add_rejects_existing_files() {
     let mut ledger = FileLedger::new();
 
     // Add initial file
@@ -213,19 +213,16 @@ fn test_batch_add_overwrites_existing_files() {
         dummy_metadata("existing", 999, 5), // Overwrite
         dummy_metadata("new_file", 200, 4),
     ];
-    ledger.add_files(&files).unwrap();
-
-    assert_eq!(ledger.files.len(), 2);
-    assert_eq!(
-        ledger.files.get("existing").unwrap().entry.root,
-        FieldElement::from(999u64),
-        "Existing file should be overwritten"
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    let err = ledger
+        .add_files(&indexed)
+        .expect_err("Existing file_id should be rejected");
+    assert!(
+        matches!(err, kontor_crypto::KontorPoRError::InvalidInput(_)),
+        "Expected InvalidInput for existing file_id, got: {err:?}"
     );
-    assert_ne!(
-        ledger.tree.root(),
-        original_root,
-        "Root should change after overwrite"
-    );
+    assert_eq!(ledger.files.len(), 1);
+    assert_eq!(ledger.tree.root(), original_root);
 }
 
 // ===========================================
@@ -245,11 +242,18 @@ fn test_batch_add_after_individual_adds() {
         .unwrap();
 
     // Then batch add more files
-    let batch_files = vec![
+    let batch_files = [
         dummy_metadata("batch_1", 300, 5),
         dummy_metadata("batch_2", 400, 3),
     ];
-    ledger.add_files(&batch_files).unwrap();
+    let indexed = batch_files
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| {
+            TestFileMetadataRow::new(metadata.clone(), ledger.next_ledger_index() + offset)
+        })
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
 
     assert_eq!(ledger.files.len(), 4, "Should have 4 files total");
     assert!(ledger.files.contains_key("individual_1"));
@@ -267,7 +271,8 @@ fn test_individual_add_after_batch_add() {
         dummy_metadata("batch_1", 100, 3),
         dummy_metadata("batch_2", 200, 4),
     ];
-    ledger.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger.add_files(&indexed).unwrap();
 
     // Then add individually
     ledger
@@ -290,9 +295,10 @@ fn test_lookup_after_batch_add() {
         dummy_metadata("banana", 200, 4),
         dummy_metadata("cherry", 300, 5),
     ];
-    ledger.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger.add_files(&indexed).unwrap();
 
-    // Indices should be in lexicographic order
+    // Indices should follow the supplied reconstruction order
     let (idx_apple, rc_apple) = ledger.lookup("apple").expect("apple should be found");
     let (idx_banana, rc_banana) = ledger.lookup("banana").expect("banana should be found");
     let (idx_cherry, rc_cherry) = ledger.lookup("cherry").expect("cherry should be found");
@@ -314,13 +320,19 @@ fn test_lookup_after_batch_add() {
 fn test_aggregation_proof_after_batch_add() {
     let mut ledger = FileLedger::new();
 
-    let files = vec![
+    let files = [
         dummy_metadata("file_1", 100, 3),
         dummy_metadata("file_2", 200, 4),
         dummy_metadata("file_3", 300, 5),
         dummy_metadata("file_4", 400, 3),
     ];
-    ledger.add_files(&files).unwrap();
+    let indexed = files
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(ledger_index, metadata)| TestFileMetadataRow::new(metadata, ledger_index))
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
 
     // Get aggregation proof for each file
     for file_id in ["file_1", "file_2", "file_3", "file_4"] {
@@ -363,7 +375,8 @@ fn test_batch_add_tree_depth_progression() {
             .map(|i| dummy_metadata(&format!("file_{}", i), i as u64, 3))
             .collect();
 
-        ledger.add_files(&files).unwrap();
+        let indexed = collect_test_file_metadata_rows(files.clone());
+        ledger.add_files(&indexed).unwrap();
 
         assert_eq!(
             ledger.depth(),
@@ -389,12 +402,12 @@ fn test_batch_add_large_batch() {
         .collect();
 
     ledger
-        .add_files(&files)
+        .add_files(&collect_test_file_metadata_rows(files.clone()))
         .expect("Large batch should succeed");
 
     assert_eq!(ledger.files.len(), 100);
 
-    // Verify ordering (BTreeMap sorts lexicographically)
+    // Verify map-key ordering (the `files` map remains lexicographically sorted by key).
     let keys: Vec<_> = ledger.files.keys().collect();
     assert_eq!(*keys[0], "file_000");
     assert_eq!(*keys[50], "file_050");
@@ -417,7 +430,8 @@ fn test_batch_vs_individual_large_dataset() {
 
     // Batch add
     let mut ledger_batch = FileLedger::new();
-    ledger_batch.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger_batch.add_files(&indexed).unwrap();
 
     // Verify identical results
     assert_eq!(ledger_individual.tree.root(), ledger_batch.tree.root());
@@ -449,7 +463,8 @@ fn test_batch_add_with_iter() {
 
     // Using .iter() explicitly
     let mut ledger = FileLedger::new();
-    ledger.add_files(files.iter()).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger.add_files(&indexed).unwrap();
 
     assert_eq!(ledger.files.len(), 3);
 }
@@ -466,9 +481,9 @@ fn test_batch_add_with_filter() {
 
     // Filter to only add files with depth > 3
     let mut ledger = FileLedger::new();
-    ledger
-        .add_files(files.iter().filter(|m| m.depth() > 3))
-        .unwrap();
+    let filtered: Vec<_> = files.into_iter().filter(|m| m.depth() > 3).collect();
+    let indexed = collect_test_file_metadata_rows(filtered.clone());
+    ledger.add_files(&indexed).unwrap();
 
     assert_eq!(ledger.files.len(), 2);
     assert!(ledger.files.contains_key("large_1"));
@@ -495,7 +510,8 @@ fn test_batch_add_with_real_files() {
 
     // Batch add
     let mut ledger_batch = FileLedger::new();
-    ledger_batch.add_files(&metadatas).unwrap();
+    let indexed = collect_test_file_metadata_rows(metadatas.clone());
+    ledger_batch.add_files(&indexed).unwrap();
 
     // Individual adds for comparison
     let mut ledger_individual = FileLedger::new();
@@ -560,7 +576,8 @@ fn test_add_files_does_not_record_historical_roots() {
         dummy_metadata("file_b", 200, 3),
         dummy_metadata("file_c", 300, 3),
     ];
-    ledger.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger.add_files(&indexed).unwrap();
 
     assert_eq!(
         historical_root_total(&ledger),
@@ -570,11 +587,18 @@ fn test_add_files_does_not_record_historical_roots() {
     assert_eq!(ledger.files.len(), 3);
 
     // Case 2: Batch add to non-empty ledger (still no historical root)
-    let more_files = vec![
+    let more_files = [
         dummy_metadata("file_d", 400, 3),
         dummy_metadata("file_e", 500, 3),
     ];
-    ledger.add_files(&more_files).unwrap();
+    let indexed_more = more_files
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| {
+            TestFileMetadataRow::new(metadata.clone(), ledger.next_ledger_index() + offset)
+        })
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed_more).unwrap();
 
     assert_eq!(
         historical_root_total(&ledger),
@@ -608,11 +632,18 @@ fn test_historical_roots_accumulate_with_add_file() {
     );
 
     // add_files does NOT add historical roots
-    let batch = vec![
+    let batch = [
         dummy_metadata("batch_1", 600, 3),
         dummy_metadata("batch_2", 700, 3),
     ];
-    ledger.add_files(&batch).unwrap();
+    let indexed = batch
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| {
+            TestFileMetadataRow::new(metadata.clone(), ledger.next_ledger_index() + offset)
+        })
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
 
     assert_eq!(
         historical_root_total(&ledger),
@@ -696,12 +727,19 @@ fn test_add_files_atomicity_state_consistency() {
     let historical_count_before = historical_root_total(&ledger);
 
     // Batch add
-    let batch = vec![
+    let batch = [
         dummy_metadata("batch_1", 200, 3),
         dummy_metadata("batch_2", 300, 3),
         dummy_metadata("batch_3", 400, 3),
     ];
-    ledger.add_files(&batch).unwrap();
+    let indexed = batch
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| {
+            TestFileMetadataRow::new(metadata.clone(), ledger.next_ledger_index() + offset)
+        })
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
 
     // State should be fully updated atomically
     assert_eq!(
@@ -730,8 +768,8 @@ fn test_empty_batch_does_not_record_historical_root() {
     let historical_count_before = historical_root_total(&ledger);
 
     // Add empty batch - should be a complete no-op
-    let empty: Vec<api::FileMetadata> = vec![];
-    ledger.add_files(&empty).unwrap();
+    let indexed_empty: Vec<TestFileMetadataRow> = vec![];
+    ledger.add_files(&indexed_empty).unwrap();
 
     // Root should not change
     assert_eq!(
@@ -759,8 +797,8 @@ fn test_empty_batch_is_true_noop() {
     let mut ledger_empty = FileLedger::new();
     let root_before_empty = ledger_empty.tree.root();
 
-    let empty: Vec<api::FileMetadata> = vec![];
-    ledger_empty.add_files(&empty).unwrap();
+    let indexed_empty: Vec<TestFileMetadataRow> = vec![];
+    ledger_empty.add_files(&indexed_empty).unwrap();
 
     assert_eq!(
         ledger_empty.files.len(),
@@ -789,7 +827,8 @@ fn test_empty_batch_is_true_noop() {
 
     // Multiple empty batches should all be no-ops
     for _ in 1002..1005 {
-        ledger.add_files(&empty).unwrap();
+        let indexed_empty: Vec<TestFileMetadataRow> = vec![];
+        ledger.add_files(&indexed_empty).unwrap();
     }
 
     assert_eq!(ledger.files.len(), files_before, "File count unchanged");
@@ -813,12 +852,17 @@ fn test_add_file_and_batch_interleaved() {
     assert_eq!(historical_root_total(&ledger), 1);
 
     // Batch add - does NOT record historical root
-    ledger
-        .add_files(&[
-            dummy_metadata("batch_1", 200, 3),
-            dummy_metadata("batch_2", 300, 3),
-        ])
-        .unwrap();
+    let batch = [
+        dummy_metadata("batch_1", 200, 3),
+        dummy_metadata("batch_2", 300, 3),
+    ];
+    let start_index = ledger.next_ledger_index();
+    let indexed = batch
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| TestFileMetadataRow::new(metadata.clone(), start_index + offset))
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
     assert_eq!(ledger.files.len(), 3);
     assert_eq!(historical_root_total(&ledger), 1); // unchanged
 
@@ -828,9 +872,14 @@ fn test_add_file_and_batch_interleaved() {
     assert_eq!(historical_root_total(&ledger), 2);
 
     // Another batch - does NOT record historical root
-    ledger
-        .add_files(&[dummy_metadata("batch_3", 500, 3)])
-        .unwrap();
+    let batch = [dummy_metadata("batch_3", 500, 3)];
+    let start_index = ledger.next_ledger_index();
+    let indexed = batch
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| TestFileMetadataRow::new(metadata.clone(), start_index + offset))
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
     assert_eq!(ledger.files.len(), 5);
     assert_eq!(historical_root_total(&ledger), 2); // unchanged
 

--- a/tests/ledger_batch_add.rs
+++ b/tests/ledger_batch_add.rs
@@ -73,10 +73,10 @@ fn test_batch_add_single_file() {
     assert_eq!(ledger.files.len(), 1);
     assert!(ledger.files.contains_key("only_file"));
     assert_eq!(
-        ledger.files.get("only_file").unwrap().root,
+        ledger.files.get("only_file").unwrap().entry.root,
         FieldElement::from(999u64)
     );
-    assert_eq!(ledger.files.get("only_file").unwrap().depth, 5);
+    assert_eq!(ledger.files.get("only_file").unwrap().entry.depth, 5);
 }
 
 // ===========================================
@@ -120,10 +120,10 @@ fn test_batch_add_equivalent_to_individual_adds() {
             .files
             .get(key)
             .expect("File should exist in batch ledger");
-        assert_eq!(entry_individual.root, entry_batch.root);
-        assert_eq!(entry_individual.depth, entry_batch.depth);
+        assert_eq!(entry_individual.entry.root, entry_batch.entry.root);
+        assert_eq!(entry_individual.entry.depth, entry_batch.entry.depth);
         assert_eq!(
-            entry_individual.rc, entry_batch.rc,
+            entry_individual.entry.rc, entry_batch.entry.rc,
             "Root commitments must match for {}",
             key
         );
@@ -132,7 +132,7 @@ fn test_batch_add_equivalent_to_individual_adds() {
 
 #[test]
 fn test_batch_add_order_independence() {
-    // BTreeMap ensures deterministic ordering regardless of insertion order
+    // With append-only stable indices, insertion order defines index assignment.
     let files_order1 = vec![
         dummy_metadata("zebra", 1, 3),
         dummy_metadata("apple", 2, 3),
@@ -151,16 +151,20 @@ fn test_batch_add_order_independence() {
     let mut ledger2 = FileLedger::new();
     ledger2.add_files(&files_order2).unwrap();
 
-    assert_eq!(
+    assert_ne!(
         ledger1.tree.root(),
         ledger2.tree.root(),
-        "Different insertion orders must produce identical root (BTreeMap sorts by key)"
+        "Different insertion orders should produce different roots with append-only indices"
     );
 
-    // Verify canonical indices are the same
-    assert_eq!(ledger1.lookup("apple").unwrap().0, 0);
-    assert_eq!(ledger1.lookup("mango").unwrap().0, 1);
-    assert_eq!(ledger1.lookup("zebra").unwrap().0, 2);
+    // Verify index assignment tracks insertion order.
+    assert_eq!(ledger1.lookup("zebra").unwrap().0, 0);
+    assert_eq!(ledger1.lookup("apple").unwrap().0, 1);
+    assert_eq!(ledger1.lookup("mango").unwrap().0, 2);
+
+    assert_eq!(ledger2.lookup("apple").unwrap().0, 0);
+    assert_eq!(ledger2.lookup("mango").unwrap().0, 1);
+    assert_eq!(ledger2.lookup("zebra").unwrap().0, 2);
 }
 
 // ===========================================
@@ -185,11 +189,14 @@ fn test_batch_add_with_duplicates_in_batch() {
     // The last duplicate should win
     let dup_entry = ledger.files.get("dup_file").unwrap();
     assert_eq!(
-        dup_entry.root,
+        dup_entry.entry.root,
         FieldElement::from(999u64),
         "Last duplicate root should be used"
     );
-    assert_eq!(dup_entry.depth, 5, "Last duplicate depth should be used");
+    assert_eq!(
+        dup_entry.entry.depth, 5,
+        "Last duplicate depth should be used"
+    );
 }
 
 #[test]
@@ -210,7 +217,7 @@ fn test_batch_add_overwrites_existing_files() {
 
     assert_eq!(ledger.files.len(), 2);
     assert_eq!(
-        ledger.files.get("existing").unwrap().root,
+        ledger.files.get("existing").unwrap().entry.root,
         FieldElement::from(999u64),
         "Existing file should be overwritten"
     );
@@ -503,8 +510,8 @@ fn test_batch_add_with_real_files() {
     // Verify each file is correctly stored
     for metadata in &metadatas {
         let entry = ledger_batch.files.get(&metadata.file_id).unwrap();
-        assert_eq!(entry.root, metadata.root);
-        assert_eq!(entry.depth, metadata.depth());
+        assert_eq!(entry.entry.root, metadata.root);
+        assert_eq!(entry.entry.depth, metadata.depth());
     }
 }
 

--- a/tests/ledger_state_changes.rs
+++ b/tests/ledger_state_changes.rs
@@ -8,6 +8,7 @@ use kontor_crypto::{
 use std::collections::BTreeMap;
 
 mod common;
+use common::fixtures::collect_test_file_metadata_rows;
 
 #[test]
 fn test_file_removal_invalidates_proof() {
@@ -299,9 +300,9 @@ fn test_add_files_bulk_initialization() {
 
     // Bulk initialize ledger with all files at once
     let mut ledger = FileLedger::new();
-    ledger
-        .add_files(&[metadata1, metadata2, metadata3])
-        .expect("Bulk add should succeed");
+    let metadatas = vec![metadata1, metadata2, metadata3];
+    let indexed = collect_test_file_metadata_rows(metadatas.clone());
+    ledger.add_files(&indexed).expect("Bulk add should succeed");
 
     assert!(
         ledger.historical_roots.is_empty(),

--- a/tests/ledger_state_changes.rs
+++ b/tests/ledger_state_changes.rs
@@ -89,8 +89,8 @@ fn test_file_removal_invalidates_proof() {
 
 #[test]
 fn test_ledger_reorg_changes_aggregated_root() {
-    // Test that reorganizing the ledger (same files, different order) changes the root
-    // Note: BTreeMap sorts by key, so file order is deterministic by file_id
+    // Test that reorganizing insertion order (same files, different order) changes the root
+    // because stable append-only ledger indices are assigned in insertion order.
     println!("Testing ledger reorganization impact");
 
     // Create files with specific names to control ordering
@@ -116,17 +116,16 @@ fn test_ledger_reorg_changes_aggregated_root() {
     ledger1.add_file(&prepared_files[2].0).unwrap();
     let root1 = ledger1.tree.root();
 
-    // Create another ledger with same files (BTreeMap ensures same order)
+    // Create another ledger with same files but a different insertion order.
     let mut ledger2 = FileLedger::new();
     ledger2.add_file(&prepared_files[2].0).unwrap();
     ledger2.add_file(&prepared_files[0].0).unwrap();
     ledger2.add_file(&prepared_files[1].0).unwrap();
     let root2 = ledger2.tree.root();
 
-    // Due to BTreeMap sorting, both ledgers should have the same order and root
-    assert_eq!(
+    assert_ne!(
         root1, root2,
-        "Ledgers with same files should have same root due to BTreeMap ordering"
+        "Ledgers with same files but different insertion order should differ with append-only indices"
     );
 
     // Now test with different file roots (simulating file content changes)

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -167,11 +167,8 @@ fn test_proof_replay_with_different_files_is_rejected() {
     // to answer a verifier's challenge for files {A, C}.
     //
     // Security is enforced at two levels:
-    // 1. API level: proof.challenge_ids must match the challenges being verified
+    // 1. Verifier-derived challenge set binding (initial_state + sorted challenge IDs)
     // 2. Cryptographic level: SNARK proves indices are correct for the claimed root
-    //
-    // The challenge_ids binding ensures a proof can only answer the specific
-    // challenges it was generated for.
     use kontor_crypto::api::PorSystem;
     use std::collections::BTreeMap;
 
@@ -224,18 +221,16 @@ fn test_proof_replay_with_different_files_is_rejected() {
     ];
 
     // Attempt to verify the proof generated for {A, B} against challenges for {A, C}
-    // This should fail because proof.challenge_ids won't match challenges_ac
+    // This should fail because verifier-derived challenge binding changes initial_state/indices.
     let verification_result = system.verify(&proof_for_ab, &challenges_ac);
 
-    // The verification should return an error because challenge IDs don't match
+    // The verification should fail (returns false under ProofVerifyError).
     assert!(
-        verification_result.is_err(),
-        "Proof for files A,B should NOT verify against challenges for files A,C - challenge_ids mismatch prevents replay!"
+        matches!(verification_result, Ok(false)),
+        "Proof for files A,B should NOT verify against challenges for files A,C"
     );
 
-    println!(
-        "✓ Proof replay attack correctly rejected - challenge_ids binding working as intended"
-    );
+    println!("✓ Proof replay attack correctly rejected by verifier-derived challenge binding");
 
     // Sanity check: Verify that the original proof still works for the original challenges
     let original_verification = system

--- a/tests/security_crypto_regressions.rs
+++ b/tests/security_crypto_regressions.rs
@@ -132,9 +132,7 @@ fn build_single_file_proof_with_custom_witness_source(
 
     Proof {
         compressed_snark,
-        challenge_ids: vec![challenge.id()],
         ledger_root: statement_root,
-        ledger_indices: vec![ledger_index],
         aggregated_tree_depth: agg_depth,
     }
 }

--- a/tests/security_ledger.rs
+++ b/tests/security_ledger.rs
@@ -792,7 +792,7 @@ fn test_ledger_duplicate_file_updates_entry() {
     let result1 = ledger.add_file(&synthetic_metadata(file_id, root1, 3));
     assert!(result1.is_ok(), "First add should succeed");
 
-    let original_root = ledger.files.get(file_id).unwrap().root;
+    let original_root = ledger.files.get(file_id).unwrap().entry.root;
     assert_eq!(original_root, root1, "Initial root should be root1");
 
     // Add the same file again with a different root - this should UPDATE
@@ -801,7 +801,7 @@ fn test_ledger_duplicate_file_updates_entry() {
 
     assert!(result2.is_ok(), "Second add should succeed (update)");
     assert_eq!(
-        ledger.files.get(file_id).unwrap().root,
+        ledger.files.get(file_id).unwrap().entry.root,
         root2,
         "Root MUST be updated to new value - ledger uses insert semantics"
     );
@@ -857,7 +857,7 @@ fn test_duplicate_file_with_different_content_records_historical_root() {
 
     // File entry should have the new root
     assert_eq!(
-        ledger.files.get(file_id).unwrap().root,
+        ledger.files.get(file_id).unwrap().entry.root,
         FieldElement::from(200u64),
         "File should have updated root"
     );
@@ -926,13 +926,13 @@ fn test_duplicate_file_with_different_depth_records_historical_root() {
     let meta_depth3 = synthetic_metadata(file_id, FieldElement::from(100u64), 3);
     ledger.add_file(&meta_depth3).unwrap();
     let root_depth3 = ledger.root();
-    let rc_depth3 = ledger.files.get(file_id).unwrap().rc;
+    let rc_depth3 = ledger.files.get(file_id).unwrap().entry.rc;
 
     // Update to depth 5 (same root value, different depth)
     let meta_depth5 = synthetic_metadata(file_id, FieldElement::from(100u64), 5);
     ledger.add_file(&meta_depth5).unwrap();
     let root_depth5 = ledger.root();
-    let rc_depth5 = ledger.files.get(file_id).unwrap().rc;
+    let rc_depth5 = ledger.files.get(file_id).unwrap().entry.rc;
 
     // RC should change because rc = H(TAG_RC, root, depth)
     assert_ne!(rc_depth3, rc_depth5, "RC must change when depth changes");
@@ -985,7 +985,7 @@ fn test_multiple_updates_to_same_file_accumulate_historical_roots() {
 
     // File has the last update's root
     assert_eq!(
-        ledger.files.get(file_id).unwrap().root,
+        ledger.files.get(file_id).unwrap().entry.root,
         FieldElement::from(400u64)
     );
 
@@ -1027,8 +1027,8 @@ fn test_batch_add_produces_identical_cryptographic_commitments() {
 
     // Verify each file's rc (root commitment) is identical
     for file_id in ["file_alpha", "file_beta", "file_gamma"] {
-        let rc_individual = ledger_individual.files.get(file_id).unwrap().rc;
-        let rc_batch = ledger_batch.files.get(file_id).unwrap().rc;
+        let rc_individual = ledger_individual.files.get(file_id).unwrap().entry.rc;
+        let rc_batch = ledger_batch.files.get(file_id).unwrap().entry.rc;
         assert_eq!(
             rc_individual, rc_batch,
             "SECURITY VIOLATION: RC for {} must be identical",
@@ -1183,7 +1183,7 @@ fn test_batch_add_save_load_roundtrip() {
     for (file_id, entry) in &ledger.files {
         let loaded_entry = loaded.files.get(file_id).expect("File should exist");
         assert_eq!(
-            entry.rc, loaded_entry.rc,
+            entry.entry.rc, loaded_entry.entry.rc,
             "SECURITY VIOLATION: RC must be preserved for {}",
             file_id
         );
@@ -1194,9 +1194,10 @@ fn test_batch_add_save_load_roundtrip() {
 
 #[test]
 fn test_batch_add_canonical_ordering_security() {
-    // SECURITY: Canonical ordering must be deterministic regardless of batch order.
-    // Non-deterministic ordering could lead to proof failures or index confusion attacks.
-    println!("Testing canonical ordering security with batch add");
+    // SECURITY: Stable append-only indices must deterministically follow insertion order.
+    // Different insertion orders should produce different roots/indices, preventing
+    // accidental assumptions about lexicographic canonicalization.
+    println!("Testing insertion-order index assignment with batch add");
 
     // Same files in different batch orders
     let files_order1 = vec![
@@ -1217,35 +1218,40 @@ fn test_batch_add_canonical_ordering_security() {
     let mut ledger2 = kontor_crypto::ledger::FileLedger::new();
     ledger2.add_files(&files_order2).unwrap();
 
-    // Roots must be identical
-    assert_eq!(
+    // Roots should differ because insertion order differs.
+    assert_ne!(
         ledger1.tree.root(),
         ledger2.tree.root(),
-        "SECURITY VIOLATION: Different batch orders must produce same root"
+        "SECURITY VIOLATION: Different batch orders unexpectedly produced same root"
     );
 
-    // Canonical indices must be identical
+    // RCs must match per file, but indices must differ for at least one file.
+    let mut observed_index_difference = false;
     for file_id in ["apple", "mango", "zebra"] {
         let (idx1, rc1) = ledger1.lookup(file_id).unwrap();
         let (idx2, rc2) = ledger2.lookup(file_id).unwrap();
-        assert_eq!(
-            idx1, idx2,
-            "SECURITY VIOLATION: Canonical index for {} must be identical",
-            file_id
-        );
         assert_eq!(
             rc1, rc2,
             "SECURITY VIOLATION: RC for {} must be identical",
             file_id
         );
+        observed_index_difference |= idx1 != idx2;
     }
+    assert!(
+        observed_index_difference,
+        "SECURITY VIOLATION: Expected at least one index difference across insertion orders"
+    );
 
-    // Verify expected canonical order (alphabetical)
-    assert_eq!(ledger1.lookup("apple").unwrap().0, 0);
-    assert_eq!(ledger1.lookup("mango").unwrap().0, 1);
-    assert_eq!(ledger1.lookup("zebra").unwrap().0, 2);
+    // Verify order-specific index assignment.
+    assert_eq!(ledger1.lookup("zebra").unwrap().0, 0);
+    assert_eq!(ledger1.lookup("apple").unwrap().0, 1);
+    assert_eq!(ledger1.lookup("mango").unwrap().0, 2);
 
-    println!("✓ Batch add maintains deterministic canonical ordering");
+    assert_eq!(ledger2.lookup("mango").unwrap().0, 0);
+    assert_eq!(ledger2.lookup("zebra").unwrap().0, 1);
+    assert_eq!(ledger2.lookup("apple").unwrap().0, 2);
+
+    println!("✓ Batch add enforces deterministic insertion-order indices");
 }
 
 #[test]
@@ -1348,12 +1354,12 @@ fn test_batch_add_rc_computation_consistency() {
     // Add via individual method
     let mut ledger_individual = kontor_crypto::ledger::FileLedger::new();
     ledger_individual.add_file(&metadata).unwrap();
-    let rc_individual = ledger_individual.files.get("test_file").unwrap().rc;
+    let rc_individual = ledger_individual.files.get("test_file").unwrap().entry.rc;
 
     // Add via batch method
     let mut ledger_batch = kontor_crypto::ledger::FileLedger::new();
     ledger_batch.add_files([&metadata]).unwrap();
-    let rc_batch = ledger_batch.files.get("test_file").unwrap().rc;
+    let rc_batch = ledger_batch.files.get("test_file").unwrap().entry.rc;
 
     assert_eq!(
         rc_individual, rc_batch,
@@ -1459,10 +1465,10 @@ fn test_batch_add_with_real_files_proof_equivalence() {
 
 #[test]
 fn test_batch_add_canonical_indices_match_individual_adds() {
-    // SECURITY: The canonical index for each file must be identical whether
+    // SECURITY: The stable index for each file must be identical whether
     // the ledger was built via batch add or individual adds.
-    // Different indices would break proof verification.
-    println!("Testing canonical index equivalence between batch and individual adds");
+    // Different indices for identical insertion order would break proof verification.
+    println!("Testing stable index equivalence between batch and individual adds");
 
     // Create files with names that will sort in a specific order
     let files = vec![
@@ -1482,8 +1488,8 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
     let mut ledger_batch = kontor_crypto::ledger::FileLedger::new();
     ledger_batch.add_files(&files).unwrap();
 
-    // Verify canonical indices are identical
-    let expected_order = ["alpha", "beta", "delta", "gamma"]; // Alphabetical
+    // Verify stable indices are identical and follow insertion order.
+    let expected_order = ["delta", "alpha", "gamma", "beta"];
 
     for (expected_idx, file_id) in expected_order.iter().enumerate() {
         let (idx_individual, rc_individual) = ledger_individual
@@ -1495,12 +1501,12 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
 
         assert_eq!(
             idx_individual, expected_idx,
-            "SECURITY VIOLATION: {} should be at index {} in individual ledger, got {}",
+            "SECURITY VIOLATION: {} should be at insertion index {} in individual ledger, got {}",
             file_id, expected_idx, idx_individual
         );
         assert_eq!(
             idx_batch, expected_idx,
-            "SECURITY VIOLATION: {} should be at index {} in batch ledger, got {}",
+            "SECURITY VIOLATION: {} should be at insertion index {} in batch ledger, got {}",
             file_id, expected_idx, idx_batch
         );
         assert_eq!(
@@ -1517,7 +1523,7 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
 
     // Also verify via get_canonical_index_for_rc
     for file_id in &expected_order {
-        let rc = ledger_individual.files.get(*file_id).unwrap().rc;
+        let rc = ledger_individual.files.get(*file_id).unwrap().entry.rc;
         let idx_individual = ledger_individual.get_canonical_index_for_rc(rc);
         let idx_batch = ledger_batch.get_canonical_index_for_rc(rc);
 
@@ -1528,7 +1534,7 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
         );
     }
 
-    println!("✓ Canonical indices are identical between batch and individual adds");
+    println!("✓ Stable indices are identical between batch and individual adds");
 }
 
 // =============================================================================

--- a/tests/security_ledger.rs
+++ b/tests/security_ledger.rs
@@ -5,7 +5,10 @@ use rand::Rng;
 use std::collections::BTreeMap;
 
 mod common;
-use common::fixtures::{create_test_data, setup_test_scenario, synthetic_metadata, TestConfig};
+use common::fixtures::{
+    collect_test_file_metadata_rows, create_test_data, setup_test_scenario, synthetic_metadata,
+    TestConfig, TestFileMetadataRow,
+};
 use kontor_crypto::KontorPoRError;
 
 fn historical_root_total(ledger: &kontor_crypto::ledger::FileLedger) -> usize {
@@ -454,9 +457,9 @@ fn test_single_file_proof_survives_ledger_update() {
 
 #[test]
 fn test_multi_file_proof_valid_with_historical_root() {
-    // Multi-file proofs include ledger_root and ledger_indices.
-    // The proof remains valid as long as the root is in the historical set.
-    // No ledger snapshot needed - the proof carries its own indices.
+    // Multi-file proofs include the ledger root used during proof generation.
+    // The proof remains valid as long as that root is retained historically and
+    // the verifier can re-derive the same file indices from its ledger state.
     println!("Testing multi-file proof valid with historical root");
 
     // 1. Set up multi-file scenario with 2 files
@@ -502,14 +505,14 @@ fn test_multi_file_proof_valid_with_historical_root() {
 
     // 4. Verify using updated ledger - should work because:
     //    - proof.ledger_root is in historical_roots (automatically recorded by add_file)
-    //    - proof includes ledger_indices from proof generation time
-    //    - SNARK proves indices are correct for claimed root
+    //    - verifier-derived indices for the challenged files are unchanged
+    //    - SNARK verification is bound to the verifier's reconstructed statement
     let updated_system = api::PorSystem::new(&updated_ledger);
     let result = updated_system.verify(&multi_proof, &challenges);
 
     assert!(
         result.expect("Should complete verification"),
-        "Multi-file proof should be valid with historical root (proof carries its own indices)"
+        "Multi-file proof should be valid with historical root and verifier-derived indices"
     );
 
     println!("✓ Multi-file proof correctly validates with historical root");
@@ -763,10 +766,10 @@ fn test_ledger_file_ordering_consistency() {
             .unwrap();
     }
 
-    // Get the keys in sorted order (BTreeMap should maintain this)
+    // Get the keys in sorted order (the backing BTreeMap maintains lexicographic key order)
     let sorted_keys: Vec<_> = ledger.files.keys().cloned().collect();
 
-    // Verify alphabetical ordering
+    // Verify map-key ordering only; ledger indices are tested separately.
     assert_eq!(sorted_keys[0], "apple");
     assert_eq!(sorted_keys[1], "banana");
     assert_eq!(sorted_keys[2], "mango");
@@ -776,12 +779,9 @@ fn test_ledger_file_ordering_consistency() {
 }
 
 #[test]
-fn test_ledger_duplicate_file_updates_entry() {
-    // Test that adding the same file_id again updates the existing entry.
-    // This is the expected behavior: the ledger uses BTreeMap::insert which
-    // silently overwrites. This allows file metadata to be updated (e.g., if
-    // the file content changes and gets a new root).
-    println!("Testing duplicate file updates in ledger");
+fn test_ledger_rejects_duplicate_file_id() {
+    // SECURITY: file_id is immutable. Re-adding an existing file_id must fail.
+    println!("Testing duplicate file rejection in ledger");
 
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
 
@@ -795,15 +795,15 @@ fn test_ledger_duplicate_file_updates_entry() {
     let original_root = ledger.files.get(file_id).unwrap().entry.root;
     assert_eq!(original_root, root1, "Initial root should be root1");
 
-    // Add the same file again with a different root - this should UPDATE
+    // Add the same file again with a different root - this should FAIL
     let root2 = kontor_crypto::api::FieldElement::from(200u64);
     let result2 = ledger.add_file(&synthetic_metadata(file_id, root2, 3));
 
-    assert!(result2.is_ok(), "Second add should succeed (update)");
+    assert!(result2.is_err(), "Second add should be rejected");
     assert_eq!(
         ledger.files.get(file_id).unwrap().entry.root,
-        root2,
-        "Root MUST be updated to new value - ledger uses insert semantics"
+        root1,
+        "Root must remain unchanged after duplicate rejection"
     );
 
     // Verify only one file exists (not two)
@@ -813,14 +813,13 @@ fn test_ledger_duplicate_file_updates_entry() {
         "Should still have exactly one file entry"
     );
 
-    println!("✓ Duplicate file correctly updates existing entry");
+    println!("✓ Duplicate file_id is rejected");
 }
 
 #[test]
-fn test_duplicate_file_with_different_content_records_historical_root() {
-    // When updating a file (same file_id, different content), the ledger root changes
-    // and a new historical root should be recorded.
-    println!("Testing that updating a file (different content) records historical root");
+fn test_duplicate_file_with_different_content_is_rejected() {
+    // SECURITY: a changed file must have a new file_id; duplicates are rejected.
+    println!("Testing that duplicate file with different content is rejected");
 
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
 
@@ -832,45 +831,28 @@ fn test_duplicate_file_with_different_content_records_historical_root() {
     let root_after_v1 = ledger.root();
     assert_eq!(historical_root_total(&ledger), 1);
 
-    // Update file with different content (different root value)
+    // Attempt duplicate with different content (different root value)
     let meta_v2 = synthetic_metadata(file_id, FieldElement::from(200u64), 3);
-    ledger.add_file(&meta_v2).unwrap();
-
-    let root_after_v2 = ledger.root();
-
-    // Roots should be different
-    assert_ne!(
-        root_after_v1, root_after_v2,
-        "Ledger root must change when file content changes"
-    );
-
-    // Should have 2 historical roots (one per add_file)
-    assert_eq!(
-        historical_root_total(&ledger),
-        2,
-        "Updating file with different content should record new historical root"
-    );
-
-    // Both roots should be valid
+    let result = ledger.add_file(&meta_v2);
+    assert!(result.is_err(), "Duplicate file_id should be rejected");
+    assert_eq!(ledger.root(), root_after_v1);
+    assert_eq!(historical_root_total(&ledger), 1);
     assert!(ledger.is_valid_root(root_after_v1));
-    assert!(ledger.is_valid_root(root_after_v2));
 
-    // File entry should have the new root
+    // File entry should remain unchanged
     assert_eq!(
         ledger.files.get(file_id).unwrap().entry.root,
-        FieldElement::from(200u64),
-        "File should have updated root"
+        FieldElement::from(100u64),
+        "File entry must remain unchanged after duplicate rejection"
     );
 
-    println!("✓ File update with different content correctly records historical root");
+    println!("✓ Duplicate file with different content is rejected");
 }
 
 #[test]
-fn test_duplicate_file_with_same_content_still_records_historical_root() {
-    // Re-adding the exact same file (same file_id, same content) doesn't change
-    // the ledger root, but add_file still records the current root.
-    // This is intentional - every add_file call records the current root.
-    println!("Testing that re-adding identical file still records historical root");
+fn test_duplicate_file_with_same_content_is_rejected() {
+    // SECURITY: exact duplicates are rejected too; replaying add_file is not a no-op update.
+    println!("Testing that re-adding identical file is rejected");
 
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
 
@@ -882,41 +864,18 @@ fn test_duplicate_file_with_same_content_still_records_historical_root() {
     let root_after_first = ledger.root();
     assert_eq!(historical_root_total(&ledger), 1);
 
-    // Re-add the exact same file
-    ledger.add_file(&meta).unwrap();
+    let result = ledger.add_file(&meta);
+    assert!(result.is_err(), "Duplicate file_id should be rejected");
+    assert_eq!(ledger.root(), root_after_first);
+    assert_eq!(historical_root_total(&ledger), 1);
 
-    let root_after_second = ledger.root();
-
-    // Roots should be IDENTICAL (same file, same content)
-    assert_eq!(
-        root_after_first, root_after_second,
-        "Ledger root should NOT change when re-adding identical file"
-    );
-
-    // Should have 2 historical roots - add_file always records
-    assert_eq!(
-        historical_root_total(&ledger),
-        2,
-        "Re-adding identical file still records historical root (every add_file records)"
-    );
-
-    // Both entries are the same root
-    use ff::PrimeField;
-    let first_recorded: [u8; 32] = ledger.historical_roots[0];
-    let second_recorded: [u8; 32] = ledger.historical_roots[1];
-    let expected: [u8; 32] = root_after_first.to_repr().into();
-
-    assert_eq!(first_recorded, expected);
-    assert_eq!(second_recorded, expected);
-
-    println!("✓ Re-adding identical file correctly records historical root");
+    println!("✓ Re-adding identical file is rejected");
 }
 
 #[test]
-fn test_duplicate_file_with_different_depth_records_historical_root() {
-    // Same file_id but different depth should change the rc (root commitment)
-    // and therefore change the ledger root.
-    println!("Testing that updating file depth records historical root");
+fn test_duplicate_file_with_different_depth_is_rejected() {
+    // SECURITY: file_id immutability also forbids changing the committed depth.
+    println!("Testing that duplicate file with different depth is rejected");
 
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
 
@@ -928,52 +887,40 @@ fn test_duplicate_file_with_different_depth_records_historical_root() {
     let root_depth3 = ledger.root();
     let rc_depth3 = ledger.files.get(file_id).unwrap().entry.rc;
 
-    // Update to depth 5 (same root value, different depth)
+    // Attempt duplicate with depth 5 (same root value, different depth)
     let meta_depth5 = synthetic_metadata(file_id, FieldElement::from(100u64), 5);
-    ledger.add_file(&meta_depth5).unwrap();
-    let root_depth5 = ledger.root();
-    let rc_depth5 = ledger.files.get(file_id).unwrap().entry.rc;
-
-    // RC should change because rc = H(TAG_RC, root, depth)
-    assert_ne!(rc_depth3, rc_depth5, "RC must change when depth changes");
-
-    // Ledger root should change
-    assert_ne!(
-        root_depth3, root_depth5,
-        "Ledger root must change when file depth changes"
-    );
-
-    // Should have 2 historical roots
-    assert_eq!(historical_root_total(&ledger), 2);
+    let result = ledger.add_file(&meta_depth5);
+    assert!(result.is_err(), "Duplicate file_id should be rejected");
+    assert_eq!(ledger.root(), root_depth3);
+    assert_eq!(ledger.files.get(file_id).unwrap().entry.rc, rc_depth3);
+    assert_eq!(historical_root_total(&ledger), 1);
     assert!(ledger.is_valid_root(root_depth3));
-    assert!(ledger.is_valid_root(root_depth5));
 
-    println!("✓ File update with different depth correctly records historical root");
+    println!("✓ Duplicate file with different depth is rejected");
 }
 
 #[test]
-fn test_multiple_updates_to_same_file_accumulate_historical_roots() {
-    // Multiple updates to the same file should accumulate historical roots
-    println!("Testing that multiple file updates accumulate historical roots");
+fn test_multiple_updates_to_same_file_are_rejected() {
+    // SECURITY: repeated use of the same file_id must fail after the first add.
+    println!("Testing that repeated duplicate file additions are rejected");
 
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
 
     let file_id = "frequently_updated";
     let mut captured_roots = Vec::new();
 
-    // Add and update the file 5 times
+    // Add once, then reject subsequent attempts.
     for i in 0..5 {
         let meta = synthetic_metadata(file_id, FieldElement::from(i as u64 * 100), 3);
-        ledger.add_file(&meta).unwrap();
-        captured_roots.push(ledger.root());
+        if i == 0 {
+            ledger.add_file(&meta).unwrap();
+            captured_roots.push(ledger.root());
+        } else {
+            assert!(ledger.add_file(&meta).is_err());
+        }
     }
 
-    // Should have 5 historical roots (one per add_file)
-    assert_eq!(
-        historical_root_total(&ledger),
-        5,
-        "Multiple updates should accumulate historical roots"
-    );
+    assert_eq!(historical_root_total(&ledger), 1);
 
     // All roots should be valid
     for root in &captured_roots {
@@ -986,10 +933,10 @@ fn test_multiple_updates_to_same_file_accumulate_historical_roots() {
     // File has the last update's root
     assert_eq!(
         ledger.files.get(file_id).unwrap().entry.root,
-        FieldElement::from(400u64)
+        FieldElement::from(0u64)
     );
 
-    println!("✓ Multiple file updates correctly accumulate historical roots");
+    println!("✓ Repeated duplicate file additions are rejected");
 }
 
 // ===========================================
@@ -1016,7 +963,8 @@ fn test_batch_add_produces_identical_cryptographic_commitments() {
 
     // Method 2: Batch add
     let mut ledger_batch = kontor_crypto::ledger::FileLedger::new();
-    ledger_batch.add_files(&files_data).unwrap();
+    let indexed = collect_test_file_metadata_rows(files_data.clone());
+    ledger_batch.add_files(&indexed).unwrap();
 
     // Verify cryptographic equivalence
     assert_eq!(
@@ -1054,7 +1002,9 @@ fn test_batch_add_proof_generation_and_verification() {
 
     // Use batch add to create ledger
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
-    ledger.add_files([&metadata_1, &metadata_2]).unwrap();
+    let metadatas = vec![metadata_1.clone(), metadata_2.clone()];
+    let indexed = collect_test_file_metadata_rows(metadatas.clone());
+    ledger.add_files(&indexed).unwrap();
 
     // Generate a proof for file 1
     let challenge = api::Challenge::new(
@@ -1102,7 +1052,8 @@ fn test_batch_add_multi_file_proof_verification() {
 
     // Batch add all files to ledger
     let mut ledger = kontor_crypto::ledger::FileLedger::new();
-    ledger.add_files(&metadatas).unwrap();
+    let indexed = collect_test_file_metadata_rows(metadatas.clone());
+    ledger.add_files(&indexed).unwrap();
 
     // Create challenges for all files
     let challenges: Vec<_> = metadatas
@@ -1158,7 +1109,8 @@ fn test_batch_add_save_load_roundtrip() {
         })
         .collect();
 
-    ledger.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger.add_files(&indexed).unwrap();
     let original_root = ledger.tree.root();
     let original_count = ledger.files.len();
 
@@ -1193,40 +1145,46 @@ fn test_batch_add_save_load_roundtrip() {
 }
 
 #[test]
-fn test_batch_add_canonical_ordering_security() {
-    // SECURITY: Stable append-only indices must deterministically follow insertion order.
-    // Different insertion orders should produce different roots/indices, preventing
-    // accidental assumptions about lexicographic canonicalization.
-    println!("Testing insertion-order index assignment with batch add");
+fn test_batch_add_explicit_index_reconstruction_determinism() {
+    // SECURITY: Reconstruction must be deterministic when persisted indices are supplied.
+    // Input order should not matter if the explicit stable indices are the same.
+    println!("Testing explicit-index reconstruction determinism with batch add");
 
     // Same files in different batch orders
-    let files_order1 = vec![
+    let files_order1 = [
         synthetic_metadata("zebra", api::FieldElement::from(1u64), 3),
         synthetic_metadata("apple", api::FieldElement::from(2u64), 3),
         synthetic_metadata("mango", api::FieldElement::from(3u64), 3),
     ];
 
-    let files_order2 = vec![
+    let files_order2 = [
         synthetic_metadata("mango", api::FieldElement::from(3u64), 3),
         synthetic_metadata("zebra", api::FieldElement::from(1u64), 3),
         synthetic_metadata("apple", api::FieldElement::from(2u64), 3),
     ];
 
     let mut ledger1 = kontor_crypto::ledger::FileLedger::new();
-    ledger1.add_files(&files_order1).unwrap();
+    let indexed_order1 = vec![
+        TestFileMetadataRow::new(files_order1[0].clone(), 0),
+        TestFileMetadataRow::new(files_order1[1].clone(), 1),
+        TestFileMetadataRow::new(files_order1[2].clone(), 2),
+    ];
+    ledger1.add_files(&indexed_order1).unwrap();
 
     let mut ledger2 = kontor_crypto::ledger::FileLedger::new();
-    ledger2.add_files(&files_order2).unwrap();
+    let indexed_order2 = vec![
+        TestFileMetadataRow::new(files_order2[0].clone(), 2),
+        TestFileMetadataRow::new(files_order2[1].clone(), 0),
+        TestFileMetadataRow::new(files_order2[2].clone(), 1),
+    ];
+    ledger2.add_files(&indexed_order2).unwrap();
 
-    // Roots should differ because insertion order differs.
-    assert_ne!(
+    assert_eq!(
         ledger1.tree.root(),
         ledger2.tree.root(),
-        "SECURITY VIOLATION: Different batch orders unexpectedly produced same root"
+        "SECURITY VIOLATION: Explicit reconstruction indices must fully determine the root"
     );
 
-    // RCs must match per file, but indices must differ for at least one file.
-    let mut observed_index_difference = false;
     for file_id in ["apple", "mango", "zebra"] {
         let (idx1, rc1) = ledger1.lookup(file_id).unwrap();
         let (idx2, rc2) = ledger2.lookup(file_id).unwrap();
@@ -1235,23 +1193,23 @@ fn test_batch_add_canonical_ordering_security() {
             "SECURITY VIOLATION: RC for {} must be identical",
             file_id
         );
-        observed_index_difference |= idx1 != idx2;
+        assert_eq!(
+            idx1, idx2,
+            "SECURITY VIOLATION: Index for {} must be identical across reconstruction orders",
+            file_id
+        );
     }
-    assert!(
-        observed_index_difference,
-        "SECURITY VIOLATION: Expected at least one index difference across insertion orders"
-    );
 
-    // Verify order-specific index assignment.
+    // Verify persisted index assignment.
     assert_eq!(ledger1.lookup("zebra").unwrap().0, 0);
     assert_eq!(ledger1.lookup("apple").unwrap().0, 1);
     assert_eq!(ledger1.lookup("mango").unwrap().0, 2);
 
-    assert_eq!(ledger2.lookup("mango").unwrap().0, 0);
-    assert_eq!(ledger2.lookup("zebra").unwrap().0, 1);
-    assert_eq!(ledger2.lookup("apple").unwrap().0, 2);
+    assert_eq!(ledger2.lookup("zebra").unwrap().0, 0);
+    assert_eq!(ledger2.lookup("apple").unwrap().0, 1);
+    assert_eq!(ledger2.lookup("mango").unwrap().0, 2);
 
-    println!("✓ Batch add enforces deterministic insertion-order indices");
+    println!("✓ Batch add deterministically reconstructs persisted indices");
 }
 
 #[test]
@@ -1269,7 +1227,8 @@ fn test_batch_add_aggregation_proof_integrity() {
         synthetic_metadata("file_c", api::FieldElement::from(300u64), 5),
         synthetic_metadata("file_d", api::FieldElement::from(400u64), 3),
     ];
-    ledger.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger.add_files(&indexed).unwrap();
 
     // Get aggregation proof for each file and verify structure
     for file_id in ["file_a", "file_b", "file_c", "file_d"] {
@@ -1319,13 +1278,16 @@ fn test_batch_add_ledger_root_changes_with_different_files() {
     ];
 
     let mut ledger_a = kontor_crypto::ledger::FileLedger::new();
-    ledger_a.add_files(&files_a).unwrap();
+    let indexed_a = collect_test_file_metadata_rows(files_a.clone());
+    ledger_a.add_files(&indexed_a).unwrap();
 
     let mut ledger_b = kontor_crypto::ledger::FileLedger::new();
-    ledger_b.add_files(&files_b).unwrap();
+    let indexed_b = collect_test_file_metadata_rows(files_b.clone());
+    ledger_b.add_files(&indexed_b).unwrap();
 
     let mut ledger_c = kontor_crypto::ledger::FileLedger::new();
-    ledger_c.add_files(&files_c).unwrap();
+    let indexed_c = collect_test_file_metadata_rows(files_c.clone());
+    ledger_c.add_files(&indexed_c).unwrap();
 
     // All roots must be different
     assert_ne!(
@@ -1358,7 +1320,9 @@ fn test_batch_add_rc_computation_consistency() {
 
     // Add via batch method
     let mut ledger_batch = kontor_crypto::ledger::FileLedger::new();
-    ledger_batch.add_files([&metadata]).unwrap();
+    let metadatas = vec![metadata.clone()];
+    let indexed = collect_test_file_metadata_rows(metadatas.clone());
+    ledger_batch.add_files(&indexed).unwrap();
     let rc_batch = ledger_batch.files.get("test_file").unwrap().entry.rc;
 
     assert_eq!(
@@ -1400,7 +1364,9 @@ fn test_batch_add_with_real_files_proof_equivalence() {
 
     // Create ledger via batch add
     let mut ledger_batch = kontor_crypto::ledger::FileLedger::new();
-    ledger_batch.add_files([&metadata_1, &metadata_2]).unwrap();
+    let metadatas = vec![metadata_1.clone(), metadata_2.clone()];
+    let indexed = collect_test_file_metadata_rows(metadatas.clone());
+    ledger_batch.add_files(&indexed).unwrap();
 
     // Roots must be identical
     assert_eq!(
@@ -1464,13 +1430,13 @@ fn test_batch_add_with_real_files_proof_equivalence() {
 }
 
 #[test]
-fn test_batch_add_canonical_indices_match_individual_adds() {
+fn test_batch_add_stable_indices_match_individual_adds() {
     // SECURITY: The stable index for each file must be identical whether
     // the ledger was built via batch add or individual adds.
     // Different indices for identical insertion order would break proof verification.
     println!("Testing stable index equivalence between batch and individual adds");
 
-    // Create files with names that will sort in a specific order
+    // Create files in a deliberate insertion order so stable indices are predictable.
     let files = vec![
         synthetic_metadata("delta", FieldElement::from(400u64), 3),
         synthetic_metadata("alpha", FieldElement::from(100u64), 4),
@@ -1478,7 +1444,7 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
         synthetic_metadata("beta", FieldElement::from(200u64), 3),
     ];
 
-    // Build ledger via individual adds (in random order)
+    // Build ledger via individual adds in that same insertion order.
     let mut ledger_individual = kontor_crypto::ledger::FileLedger::new();
     for metadata in files.iter() {
         ledger_individual.add_file(metadata).unwrap();
@@ -1486,7 +1452,8 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
 
     // Build ledger via batch add (same order)
     let mut ledger_batch = kontor_crypto::ledger::FileLedger::new();
-    ledger_batch.add_files(&files).unwrap();
+    let indexed = collect_test_file_metadata_rows(files.clone());
+    ledger_batch.add_files(&indexed).unwrap();
 
     // Verify stable indices are identical and follow insertion order.
     let expected_order = ["delta", "alpha", "gamma", "beta"];
@@ -1511,7 +1478,7 @@ fn test_batch_add_canonical_indices_match_individual_adds() {
         );
         assert_eq!(
             idx_individual, idx_batch,
-            "SECURITY VIOLATION: Canonical index for {} differs between batch ({}) and individual ({})",
+            "SECURITY VIOLATION: Stable index for {} differs between batch ({}) and individual ({})",
             file_id, idx_batch, idx_individual
         );
         assert_eq!(
@@ -1619,12 +1586,19 @@ fn test_add_files_does_not_record_historical_roots() {
     assert_eq!(historical_root_total(&ledger), 1);
 
     // Batch add multiple files - should NOT record any historical roots
-    let batch = vec![
+    let batch = [
         synthetic_metadata("file_2", FieldElement::from(200u64), 3),
         synthetic_metadata("file_3", FieldElement::from(300u64), 3),
         synthetic_metadata("file_4", FieldElement::from(400u64), 3),
     ];
-    ledger.add_files(&batch).unwrap();
+    let indexed = batch
+        .iter()
+        .enumerate()
+        .map(|(offset, metadata)| {
+            TestFileMetadataRow::new(metadata.clone(), ledger.next_ledger_index() + offset)
+        })
+        .collect::<Vec<_>>();
+    ledger.add_files(&indexed).unwrap();
 
     assert_eq!(
         historical_root_total(&ledger),
@@ -2053,8 +2027,8 @@ fn test_empty_batch_is_noop_no_historical_root() {
     let history_before = ledger.historical_roots.len();
 
     // Empty batch
-    let empty: Vec<&api::FileMetadata> = vec![];
-    ledger.add_files(empty).unwrap();
+    let indexed_empty: Vec<TestFileMetadataRow> = vec![];
+    ledger.add_files(&indexed_empty).unwrap();
 
     // Verify complete no-op
     assert_eq!(ledger.root(), root_before, "Root should not change");

--- a/tests/security_replay_attack.rs
+++ b/tests/security_replay_attack.rs
@@ -149,8 +149,8 @@ fn test_verify_raw_rejects_rebinding_non_circuit_challenge_fields() {
 }
 
 #[test]
-fn test_verify_raw_rejects_rebinding_even_with_rewritten_proof_challenge_ids() {
-    // A malicious prover can rewrite proof.challenge_ids. Verification must still
+fn test_verify_raw_rejects_rebinding_after_proof_serialization_roundtrip() {
+    // Even after re-encoding/re-decoding proof bytes, verify_raw must still
     // reject rebinding of non-circuit challenge fields.
     let setup = setup_test_scenario(&TestConfig::default()).unwrap();
     let file_refs = setup.file_refs();
@@ -159,22 +159,24 @@ fn test_verify_raw_rejects_rebinding_even_with_rewritten_proof_challenge_ids() {
         .expect("Ledger should be available for unified API");
     let system = kontor_crypto::api::PorSystem::new(ledger);
     let files_vec: Vec<&_> = file_refs.values().copied().collect();
-    let mut proof = system
+    let proof = system
         .prove(files_vec, &setup.challenges)
         .expect("Should generate valid proof");
+    let proof_bytes = proof
+        .to_bytes()
+        .expect("proof serialization should succeed");
+    let proof =
+        kontor_crypto::api::Proof::from_bytes(&proof_bytes).expect("proof decode should succeed");
 
     let mut tampered_challenges = setup.challenges.clone();
     tampered_challenges[0].block_height = tampered_challenges[0].block_height.saturating_add(1);
-
-    // Simulate attacker rewriting proof metadata to match tampered challenges.
-    proof.challenge_ids = tampered_challenges.iter().map(|c| c.id()).collect();
 
     let result = kontor_crypto::api::verify_raw(&tampered_challenges, &proof, ledger)
         .expect("Verification should complete");
 
     assert!(
         !result,
-        "SECURITY VIOLATION: verify_raw accepted proof after rebinding + challenge_ids rewrite"
+        "SECURITY VIOLATION: verify_raw accepted proof after rebinding post-serialization"
     );
 }
 
@@ -188,13 +190,12 @@ fn test_verify_raw_rejects_non_member_file_id_even_with_matching_root() {
         .expect("Ledger should be available for unified API");
     let system = kontor_crypto::api::PorSystem::new(ledger);
     let files_vec: Vec<&_> = file_refs.values().copied().collect();
-    let mut proof = system
+    let proof = system
         .prove(files_vec, &setup.challenges)
         .expect("Should generate valid proof");
 
     let mut tampered_challenges = setup.challenges.clone();
     tampered_challenges[0].file_metadata.file_id = "file_non_member".to_string();
-    proof.challenge_ids = tampered_challenges.iter().map(|c| c.id()).collect();
 
     let result = kontor_crypto::api::verify_raw(&tampered_challenges, &proof, ledger);
     match result {

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -519,9 +519,12 @@ fn test_verify_fails_with_mismatched_challenge_counts() {
     let mut modified_challenges = setup.challenges.clone();
     modified_challenges[1].num_challenges += 1;
 
-    // Verification should fail due to mismatched challenge IDs (caused by different num_challenges)
+    // Verification should fail due to inconsistent num_challenges across inputs.
     let result = system.verify(&proof, &modified_challenges);
-    assert_verify_fails_contains(result, Some("Challenge ID mismatch"));
+    assert_verify_fails_contains(
+        result,
+        Some("All challenges must have the same num_challenges for verification"),
+    );
 
     println!("✓ Mismatched num_challenges in verification correctly rejected");
 }

--- a/tests/verifier_edge_cases.rs
+++ b/tests/verifier_edge_cases.rs
@@ -53,7 +53,7 @@ fn test_verifier_rejects_out_of_range_ledger_index() {
 }
 
 #[test]
-fn test_verifier_rejects_ledger_indices_length_mismatch() {
+fn test_verifier_rejects_zero_aggregated_tree_depth_for_multifile() {
     // Verifier should reject multi-file proofs with aggregated_tree_depth = 0.
     let data_a = vec![3u8; 100];
     let data_b = vec![4u8; 100];

--- a/tests/verifier_edge_cases.rs
+++ b/tests/verifier_edge_cases.rs
@@ -2,13 +2,12 @@
 
 use kontor_crypto::api::{self, Challenge, FieldElement};
 use kontor_crypto::KontorPoRError;
-use rand::RngCore;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
-fn random_nonce() -> [u8; 16] {
-    let mut nonce = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut nonce);
-    nonce
+fn nonce(label: &str) -> [u8; 16] {
+    let digest = Sha256::digest(label.as_bytes());
+    digest[..16].try_into().expect("slice is 16 bytes")
 }
 
 #[test]
@@ -18,9 +17,9 @@ fn test_verifier_rejects_out_of_range_ledger_index() {
     let data_a = vec![1u8; 100];
     let data_b = vec![2u8; 100];
     let data_c = vec![3u8; 100];
-    let (prepared_a, meta_a) = api::prepare_file(&data_a, "a.dat", &random_nonce()).unwrap();
-    let (prepared_b, meta_b) = api::prepare_file(&data_b, "b.dat", &random_nonce()).unwrap();
-    let (prepared_c, meta_c) = api::prepare_file(&data_c, "c.dat", &random_nonce()).unwrap();
+    let (prepared_a, meta_a) = api::prepare_file(&data_a, "a.dat", &nonce("a")).unwrap();
+    let (prepared_b, meta_b) = api::prepare_file(&data_b, "b.dat", &nonce("b")).unwrap();
+    let (prepared_c, meta_c) = api::prepare_file(&data_c, "c.dat", &nonce("c")).unwrap();
 
     let mut ledger = kontor_crypto::FileLedger::new();
     ledger.add_file(&meta_a).unwrap();

--- a/tests/verifier_edge_cases.rs
+++ b/tests/verifier_edge_cases.rs
@@ -6,43 +6,49 @@ use std::collections::BTreeMap;
 
 #[test]
 fn test_verifier_rejects_out_of_range_ledger_index() {
-    // Verifier should reject ledger_indices >= 2^aggregated_tree_depth, since the circuit
-    // only consumes low bits and would otherwise permit non-canonical indices.
+    // Verifier should reject proofs when derived ledger indices don't fit the claimed
+    // aggregated tree depth.
     let data_a = vec![1u8; 100];
     let data_b = vec![2u8; 100];
+    let data_c = vec![3u8; 100];
     let (prepared_a, meta_a) = api::prepare_file(&data_a, "a.dat", b"").unwrap();
     let (prepared_b, meta_b) = api::prepare_file(&data_b, "b.dat", b"").unwrap();
+    let (prepared_c, meta_c) = api::prepare_file(&data_c, "c.dat", b"").unwrap();
 
     let mut ledger = kontor_crypto::FileLedger::new();
     ledger.add_file(&meta_a).unwrap();
     ledger.add_file(&meta_b).unwrap();
+    ledger.add_file(&meta_c).unwrap();
 
     let challenges = vec![
         Challenge::new_test(meta_a.clone(), 1000, 1, FieldElement::from(1u64)),
         Challenge::new_test(meta_b.clone(), 1000, 1, FieldElement::from(2u64)),
+        Challenge::new_test(meta_c.clone(), 1000, 1, FieldElement::from(3u64)),
     ];
 
     let system = kontor_crypto::api::PorSystem::new(&ledger);
     let mut proof = system
-        .prove(vec![&prepared_a, &prepared_b], &challenges)
+        .prove(vec![&prepared_a, &prepared_b, &prepared_c], &challenges)
         .expect("Should generate a valid multi-file proof");
 
-    assert!(proof.aggregated_tree_depth > 0, "Must be multi-file proof");
+    assert!(
+        proof.aggregated_tree_depth > 1,
+        "Must have at least depth 2 for 3-file proof"
+    );
 
-    // Make ledger_index out of range: max is (1<<depth)-1, so choose 1<<depth.
-    let out_of_range = 1usize << proof.aggregated_tree_depth;
-    proof.ledger_indices[0] = out_of_range;
+    // Shrink claimed depth so derived index 2 no longer fits range [0, 1].
+    proof.aggregated_tree_depth -= 1;
 
     let res = system.verify(&proof, &challenges);
     assert!(
         matches!(res, Err(KontorPoRError::InvalidInput(_))),
-        "Expected InvalidInput for out-of-range ledger index, got: {res:?}"
+        "Expected InvalidInput for out-of-range derived ledger index, got: {res:?}"
     );
 }
 
 #[test]
 fn test_verifier_rejects_ledger_indices_length_mismatch() {
-    // Verifier should reject proofs whose ledger_indices length doesn't match files_per_step.
+    // Verifier should reject multi-file proofs with aggregated_tree_depth = 0.
     let data_a = vec![3u8; 100];
     let data_b = vec![4u8; 100];
     let (prepared_a, meta_a) = api::prepare_file(&data_a, "a2.dat", b"").unwrap();
@@ -62,13 +68,12 @@ fn test_verifier_rejects_ledger_indices_length_mismatch() {
         .prove(vec![&prepared_a, &prepared_b], &challenges)
         .expect("Should generate a valid multi-file proof");
 
-    // Corrupt the proof: remove one index so the length doesn't match files_per_step.
-    proof.ledger_indices.pop();
+    proof.aggregated_tree_depth = 0;
 
     let res = system.verify(&proof, &challenges);
     assert!(
         matches!(res, Err(KontorPoRError::InvalidInput(_))),
-        "Expected InvalidInput for ledger_indices length mismatch, got: {res:?}"
+        "Expected InvalidInput for zero aggregated_tree_depth on multi-file proof, got: {res:?}"
     );
 }
 

--- a/tests/verifier_edge_cases.rs
+++ b/tests/verifier_edge_cases.rs
@@ -2,7 +2,14 @@
 
 use kontor_crypto::api::{self, Challenge, FieldElement};
 use kontor_crypto::KontorPoRError;
+use rand::RngCore;
 use std::collections::BTreeMap;
+
+fn random_nonce() -> [u8; 16] {
+    let mut nonce = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut nonce);
+    nonce
+}
 
 #[test]
 fn test_verifier_rejects_out_of_range_ledger_index() {
@@ -11,9 +18,9 @@ fn test_verifier_rejects_out_of_range_ledger_index() {
     let data_a = vec![1u8; 100];
     let data_b = vec![2u8; 100];
     let data_c = vec![3u8; 100];
-    let (prepared_a, meta_a) = api::prepare_file(&data_a, "a.dat", b"").unwrap();
-    let (prepared_b, meta_b) = api::prepare_file(&data_b, "b.dat", b"").unwrap();
-    let (prepared_c, meta_c) = api::prepare_file(&data_c, "c.dat", b"").unwrap();
+    let (prepared_a, meta_a) = api::prepare_file(&data_a, "a.dat", &random_nonce()).unwrap();
+    let (prepared_b, meta_b) = api::prepare_file(&data_b, "b.dat", &random_nonce()).unwrap();
+    let (prepared_c, meta_c) = api::prepare_file(&data_c, "c.dat", &random_nonce()).unwrap();
 
     let mut ledger = kontor_crypto::FileLedger::new();
     ledger.add_file(&meta_a).unwrap();


### PR DESCRIPTION
## Summary
- Makes `Proof` constant-size by removing dynamic `challenge_ids` and `ledger_indices` vectors from serialization/verification paths.
- Moves index binding to verifier-side derivation, so proofs are checked against canonical protocol/ledger state, not prover-supplied index vectors.
- Introduces stable append-only ledger indexing in `FileLedger` (format v2 semantics) for deterministic reconstruction and historical-root compatibility.
- Makes `FileLedger::add_files` atomic and guards against pathological sparse indices that could cause memory amplification on corrupted/untrusted inputs.
- Adds/updates edge and regression tests for verifier index-range handling, replay resistance, constraint integrity, and historical-ledger behavior.

## Compatibility Notes
- `Proof` wire format changed (constant-size metadata shape).
- Ledger serialization/versioning updated for stable index persistence.

## Downstream Integration
- **Kontor PR #346** consumes this verifier/proof model.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --no-fail-fast`
