### PR TITLE
Bump version, prepare packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build_and_test:
     # The type of runner that the job will run on.
-    runs-on: ubuntu-x86-8cpu
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job.
     steps:

--- a/.github/workflows/formal-picus.yml
+++ b/.github/workflows/formal-picus.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   picus_matrix:
     name: Picus ${{ matrix.lane_name }}
-    runs-on: ubuntu-x86-8cpu
+    runs-on: ubuntu-latest-m
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: publish-crates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-x86-8cpu
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Rust
+        run: rustup show
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+
+      - name: Publish kontor-crypto-core
+        run: cargo publish -p kontor-crypto-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io to index kontor-crypto-core
+        run: |
+          VERSION=$(cargo metadata --format-version 1 --no-deps -p kontor-crypto-core | jq -r '.packages[0].version')
+          echo "Waiting for kontor-crypto-core@$VERSION to appear on crates.io..."
+          for i in $(seq 1 30); do
+            if curl -sS "https://crates.io/api/v1/crates/kontor-crypto-core/$VERSION" | jq -e '.version' >/dev/null 2>&1; then
+              echo "kontor-crypto-core@$VERSION is indexed"
+              exit 0
+            fi
+            echo "  attempt $i/30 — retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Timed out waiting for crates.io to index kontor-crypto-core@$VERSION"
+          exit 1
+
+      - name: Publish kontor-crypto
+        run: cargo publish -p kontor-crypto
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-npm:
+    name: Publish to npm
+    needs: publish-crates
+    runs-on: ubuntu-x86-8cpu
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Rust
+        run: rustup show
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: |
+          if ! command -v wasm-pack >/dev/null; then
+            cargo install wasm-pack --locked --version 0.14.0
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Build package
+        working-directory: packages/kontor-crypto
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish to npm
+        working-directory: packages/kontor-crypto
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,3 @@ jobs:
       - name: Publish to npm
         working-directory: packages/kontor-crypto
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   publish-crates:
     name: Publish to crates.io
-    runs-on: ubuntu-x86-8cpu
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -50,7 +50,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: publish-crates
-    runs-on: ubuntu-x86-8cpu
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   wasm_build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   wasm_build_and_test:
-    runs-on: ubuntu-x86-8cpu
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.2.0] - 2026-04-23
+
+### Breaking changes
+
+- `field_to_hex` and `field_from_hex` now use canonical little-endian byte order (`ff::PrimeField::to_repr()`) in Rust and npm/WASM surfaces.
+- Hex strings produced by `0.1.x` are legacy big-endian and must be byte-reversed before being consumed by `0.2.0`.
+- The repository moved from a single-crate layout to a Cargo workspace; git/path consumers must update crate paths.
+
+### Added
+
+- New `kontor-crypto-core` crate with shared primitives:
+  - Reed-Solomon symbol encoding/decoding
+  - Poseidon Merkle tree logic
+  - `prepare_file` pipeline and shared metadata/types
+- New `kontor-crypto-wasm` crate exposing browser/Node bindings for `prepare_file`.
+- New npm package in `packages/kontor-crypto` for JavaScript/TypeScript integration.
+- New release automation workflow for publishing Rust crates and the npm package.
+- Expanded verification and hardening assets:
+  - formal verification tooling and docs (Picus lane)
+  - fuzzing harness and seed corpus
+  - additional regression/security test coverage
+
+### Changed
+
+- Project reorganized into a 3-crate workspace:
+  - `kontor-crypto` (main Nova prover/verifier API + CLI)
+  - `kontor-crypto-core` (shared non-Nova primitives)
+  - `kontor-crypto-wasm` (WASM bindings)
+- `kontor-crypto` now depends on `kontor-crypto-core` for shared cryptographic/data-preparation logic.
+- Documentation updated for workspace usage, WASM/browser usage, and release process.
+
+### Fixed
+
+- Corrected field hex endianness mismatch with indexer/filestorage expectations.
+- CI and release pipeline stability improvements for multi-package publication.
+- Dependency pinning to avoid edition2024 transitive breakage in constrained toolchains.
+
+### Upgrade notes (from `0.1.6`)
+
+- Regenerate or migrate any persisted field hex strings from `0.1.x` before verification/use in `0.2.0`.
+- If you depend on this repo via git path, update package paths to the workspace crate locations.
+- For browser-only `prepare_file` use cases, prefer `kontor-crypto-wasm` (or npm package) instead of shipping the full Nova stack.
+
+## [0.1.6] - 2026-01-28
+
+- Latest published crates.io release in the `0.1.x` line.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.9",
  "halo2curves",
+ "hex",
  "nova-snark",
  "once_cell",
  "reed-solomon-erasure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "kontor-crypto"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "blake2b_simd",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "kontor-crypto-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake2b_simd",
  "constant_time_eq 0.3.1",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "kontor-crypto-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ff",
  "getrandom 0.2.17",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Kontor Proof-of-Retrievability (PoR)
 
+> ## ⚠️ BREAKING CHANGE in v(next)
+>
+> `field_to_hex` and `field_from_hex` (in both Rust `kontor-crypto-core` and the npm `kontor-crypto` package) now use the **canonical little-endian** byte order of `ff::PrimeField::to_repr()`, instead of the previous big-endian order.
+>
+> This aligns the hex serialization with what the Kontor indexer (`bytes_to_field_element`) and the `filestorage` contract expect when consuming a field element via WIT. Any hex string of a field element produced by previous versions must be considered invalid (or reversed byte-by-byte) before being read by the new version. The change is binary-equivalent to applying a `byte.reverse()` on the hex output.
+>
+> See commit history for migration details.
+
 [![Crates.io](https://img.shields.io/crates/v/kontor-crypto.svg)](https://crates.io/crates/kontor-crypto)
 [![CI](https://github.com/KontorProtocol/Kontor-Crypto/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/KontorProtocol/Kontor-Crypto/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/KontorProtocol/Kontor-Crypto/blob/main/LICENSE)

--- a/crates/kontor-crypto-core/Cargo.toml
+++ b/crates/kontor-crypto-core/Cargo.toml
@@ -32,3 +32,6 @@ reed-solomon-erasure = "6.0"
 blake2b_simd = "1.0.1"
 constant_time_eq = "0.3.1"
 once_cell = "1.19"
+
+[dev-dependencies]
+hex = "0.4"

--- a/crates/kontor-crypto-core/Cargo.toml
+++ b/crates/kontor-crypto-core/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "kontor-crypto-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
+license = "MIT"
 description = "Shared cryptographic primitives for Kontor PoR (prepare_file, encode, Merkle)"
+repository = "https://github.com/KontorProtocol/Kontor-Crypto"
+homepage = "https://github.com/KontorProtocol/Kontor-Crypto"
+keywords = ["cryptography", "por", "storage", "merkle"]
+categories = ["cryptography", "algorithms"]
+readme = "../../README.md"
 
 [features]
 default = []

--- a/crates/kontor-crypto-core/src/poseidon.rs
+++ b/crates/kontor-crypto-core/src/poseidon.rs
@@ -912,14 +912,14 @@ mod tests {
         assert_eq!(
             poseidon_hash2(Fq::from(0u64), Fq::from(0u64)),
             field_from_hex::<Fq>(
-                "38ec69788c896550d69fb76411058e72798b21bcaaae2ad06101e9dc558b5dbd"
+                "bd5d8b55dce90161d02aaeaabc218b79728e051164b79fd65065898c7869ec38"
             ),
             "poseidon_hash2(0,0) must match Nova"
         );
         assert_eq!(
             poseidon_hash_tagged(domain_tags::leaf(), Fq::from(1u64), Fq::from(2u64)),
             field_from_hex::<Fq>(
-                "2eb3923b358306dc6af5240a87e8ea32ec23a2b4cc99932af880d75a86021495"
+                "951402865ad780f82a9399ccb4a223ec32eae8870a24f56adc0683353b92b32e"
             ),
             "poseidon_hash_tagged(leaf,1,2) must match Nova"
         );

--- a/crates/kontor-crypto-core/src/utils.rs
+++ b/crates/kontor-crypto-core/src/utils.rs
@@ -25,14 +25,18 @@ pub fn field_to_bytes31_le<F: PrimeField>(element: &F) -> [u8; 31] {
     out
 }
 
-/// Render a field element as a lowercase hex string (MSB-first / big-endian),
-/// consistent with [`field_from_hex`].
+/// Render a field element as a lowercase hex string in canonical
+/// `PrimeField::to_repr()` byte order (little-endian for Pallas Fq).
+///
+/// This produces the same output as `hex::encode(f.to_repr())` and is the
+/// inverse of [`field_from_hex`]. The byte order matches what the Kontor
+/// indexer (`bytes_to_field_element`) and the filestorage contract expect
+/// when consuming a `root` field via WIT.
 pub fn field_to_hex<F: PrimeField>(f: &F) -> String {
     use std::fmt::Write;
     let repr = f.to_repr();
     repr.as_ref()
         .iter()
-        .rev()
         .fold(String::with_capacity(64), |mut s, b| {
             let _ = write!(s, "{:02x}", b);
             s
@@ -40,15 +44,61 @@ pub fn field_to_hex<F: PrimeField>(f: &F) -> String {
 }
 
 /// Parse a hex string (optionally `0x`-prefixed) into a field element.
-/// Bytes are interpreted MSB-first and stored in reverse (little-endian repr).
+///
+/// Bytes are interpreted as the canonical `PrimeField::Repr`
+/// (little-endian for Pallas Fq), matching [`field_to_hex`].
 pub fn field_from_hex<F: PrimeField>(hex: &str) -> F {
     let hex = hex.trim_start_matches("0x");
     let mut buf = [0u8; 32];
     for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
         let s = core::str::from_utf8(chunk).expect("hex must be valid UTF-8");
-        buf[31 - i] = u8::from_str_radix(s, 16).expect("hex must contain valid hex digits");
+        buf[i] = u8::from_str_radix(s, 16).expect("hex must contain valid hex digits");
     }
     let mut repr = <F as PrimeField>::Repr::default();
     repr.as_mut().copy_from_slice(&buf);
     F::from_repr(repr).expect("hex value must fit in the field")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2curves::pasta::Fq;
+
+    #[test]
+    fn field_to_hex_matches_hex_encode_to_repr() {
+        // Spec invariant: field_to_hex MUST be byte-equivalent to hex::encode(fe.to_repr()).
+        for i in 0u64..100 {
+            let fe = Fq::from(i.wrapping_mul(2654435761));
+            let via_field_to_hex = field_to_hex(&fe);
+            let via_hex_encode = hex::encode(fe.to_repr());
+            assert_eq!(via_field_to_hex, via_hex_encode, "mismatch at i={i}");
+        }
+    }
+
+    #[test]
+    fn field_to_hex_field_from_hex_round_trip() {
+        for i in 0u64..100 {
+            let fe = Fq::from(i.wrapping_mul(2654435761));
+            let hex = field_to_hex(&fe);
+            let recovered: Fq = field_from_hex(&hex);
+            assert_eq!(fe, recovered, "round-trip failed at i={i}");
+        }
+    }
+
+    #[test]
+    fn field_from_hex_field_to_hex_round_trip() {
+        // hex string round-trip
+        let fe = Fq::from(0x1234_5678_9abc_def0u64);
+        let hex = field_to_hex(&fe);
+        let again = field_to_hex(&field_from_hex::<Fq>(&hex));
+        assert_eq!(hex, again);
+    }
+
+    #[test]
+    fn field_from_hex_accepts_0x_prefix() {
+        let fe = Fq::from(42u64);
+        let hex = field_to_hex(&fe);
+        let prefixed = format!("0x{hex}");
+        assert_eq!(field_from_hex::<Fq>(&prefixed), fe);
+    }
 }

--- a/crates/kontor-crypto-wasm/Cargo.toml
+++ b/crates/kontor-crypto-wasm/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "kontor-crypto-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
+license = "MIT"
+publish = false
 description = "WASM bindings for Kontor prepare_file (browser)"
 
 [lib]
@@ -9,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Core: no nova_poseidon to keep WASM-compatible (pure Rust Poseidon in core).
-kontor-crypto-core = { path = "../kontor-crypto-core", default-features = false }
+kontor-crypto-core = { path = "../kontor-crypto-core", version = "0.2.0", default-features = false }
 # Minimum version; Cargo resolves to latest compatible (currently 0.2.112).
 # rust-toolchain.toml pins 1.93.0, so any 0.2.x is fine.
 wasm-bindgen = "0.2.100"

--- a/crates/kontor-crypto-wasm/src/lib.rs
+++ b/crates/kontor-crypto-wasm/src/lib.rs
@@ -297,7 +297,6 @@ mod tests {
         let root_hex_from_bytes: String =
             desc.root
                 .iter()
-                .rev()
                 .fold(String::with_capacity(64), |mut s, b| {
                     use std::fmt::Write;
                     let _ = write!(s, "{:02x}", b);

--- a/crates/kontor-crypto/Cargo.toml
+++ b/crates/kontor-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kontor-crypto"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 default-run = "kontor-crypto"
 license = "MIT"
@@ -22,7 +22,7 @@ exclude = [
 # --- Core SNARK and Proof System Dependencies ---
 
 nova-snark = { version = "0.41.0", default-features = false }
-kontor-crypto-core = { path = "../kontor-crypto-core", features = ["nova_poseidon"] }
+kontor-crypto-core = { path = "../kontor-crypto-core", version = "0.2.0", features = ["nova_poseidon"] }
 
 # --- Hashing and Merkle Tree Dependencies ---
 

--- a/crates/kontor-crypto/tests/poseidon_regression.rs
+++ b/crates/kontor-crypto/tests/poseidon_regression.rs
@@ -16,7 +16,7 @@ fn poseidon_hash2_zero_zero() {
     assert_eq!(
         poseidon_hash2(FieldElement::from(0u64), FieldElement::from(0u64)),
         field_from_hex::<FieldElement>(
-            "38ec69788c896550d69fb76411058e72798b21bcaaae2ad06101e9dc558b5dbd"
+            "bd5d8b55dce90161d02aaeaabc218b79728e051164b79fd65065898c7869ec38"
         ),
         "poseidon_hash2(0,0)"
     );
@@ -27,7 +27,7 @@ fn poseidon_hash2_one_two() {
     assert_eq!(
         poseidon_hash2(FieldElement::from(1u64), FieldElement::from(2u64)),
         field_from_hex::<FieldElement>(
-            "041f4c4432174659e6b91ccdc53b7e47caae1cd55c46b5385c13291392283f61"
+            "613f28921329135c38b5465cd51caeca477e3bc5cd1cb9e659461732444c1f04"
         ),
         "poseidon_hash2(1,2)"
     );
@@ -42,7 +42,7 @@ fn poseidon_hash_tagged_leaf_1_2() {
             FieldElement::from(2u64)
         ),
         field_from_hex::<FieldElement>(
-            "2eb3923b358306dc6af5240a87e8ea32ec23a2b4cc99932af880d75a86021495"
+            "951402865ad780f82a9399ccb4a223ec32eae8870a24f56adc0683353b92b32e"
         ),
         "poseidon_hash_tagged(leaf,1,2)"
     );
@@ -57,7 +57,7 @@ fn poseidon_hash_tagged_node_42_123() {
             FieldElement::from(123u64),
         ),
         field_from_hex::<FieldElement>(
-            "3792b290b7368a21134c9fcd2978f2e94c91928442e524b2293ff4d4bbf2772a"
+            "2a77f2bbd4f43f29b224e5428492914ce9f27829cd9f4c13218a36b790b29237"
         ),
         "poseidon_hash_tagged(node,42,123)"
     );

--- a/crates/kontor-crypto/tests/prepare_file_regression.rs
+++ b/crates/kontor-crypto/tests/prepare_file_regression.rs
@@ -29,7 +29,7 @@ fn prepare_file_hello_deterministic() {
 
     assert_eq!(
         field_to_hex(&metadata.root),
-        "073541b34bf621116dd2e6194013c3f5d0242faaf369badb5f535a3b059086f3"
+        "f38690053b5a535fdbba69f3aa2f24d0f5c3134019e6d26d1121f64bb3413507"
     );
 
     assert_eq!(prepared.root, metadata.root);

--- a/packages/kontor-crypto/package-lock.json
+++ b/packages/kontor-crypto/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kontor-crypto",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kontor-crypto",
-      "version": "0.1.0",
+      "version": "0.2.0-alpha",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/packages/kontor-crypto/package-lock.json
+++ b/packages/kontor-crypto/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kontor-crypto",
+  "name": "@kontor/kontor-crypto",
   "version": "0.2.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kontor-crypto",
+      "name": "@kontor/kontor-crypto",
       "version": "0.2.0-alpha",
       "license": "MIT",
       "devDependencies": {

--- a/packages/kontor-crypto/package.json
+++ b/packages/kontor-crypto/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "kontor-crypto",
-  "version": "0.2.0",
+  "name": "@kontor/kontor-crypto",
+  "version": "0.2.0-alpha",
   "type": "module",
   "description": "Kontor file preparation for Proof-of-Retrievability",
   "main": "dist/index.js",

--- a/packages/kontor-crypto/package.json
+++ b/packages/kontor-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kontor-crypto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Kontor file preparation for Proof-of-Retrievability",
   "main": "dist/index.js",

--- a/packages/kontor-crypto/src/index.ts
+++ b/packages/kontor-crypto/src/index.ts
@@ -60,11 +60,11 @@ export function init(): Promise<void> {
 const HEX: string[] = [];
 for (let i = 0; i < 256; i++) HEX[i] = i.toString(16).padStart(2, "0");
 
-/** Encode a 32-byte field element repr as big-endian hex (MSB-first),
- *  matching Rust `field_to_hex` which iterates `.iter().rev()`. */
+/** Encode a 32-byte field element repr as little-endian hex (canonical
+ *  `PrimeField::to_repr()` order), matching Rust `field_to_hex`. */
 function fieldBytesToHex(bytes: Uint8Array, offset = 0, len = 32): string {
   let hex = "";
-  for (let j = offset + len - 1; j >= offset; j--) hex += HEX[bytes[j]];
+  for (let j = offset; j < offset + len; j++) hex += HEX[bytes[j]];
   return hex;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: changes canonical field-element hex encoding/decoding (breaking wire/persisted format) and updates golden test vectors, so downstream consumers may fail if not migrated; release automation also affects publication flow.
> 
> **Overview**
> **Prepares the `0.2.0` release** by adding a GitHub Actions `release.yml` workflow that publishes the Rust crates to crates.io (with an indexing wait) and then builds/publishes the npm package.
> 
> **Breaking serialization change:** `field_to_hex`/`field_from_hex` now use canonical `PrimeField::to_repr()` byte order (little-endian) across Rust core and the npm/WASM surface, with updated Poseidon/`prepare_file` golden vectors and added round-trip/unit tests to lock the invariant.
> 
> Bumps crate versions to `0.2.0`, adds missing crate metadata (`license`, etc.), renames the npm package to `@kontor/kontor-crypto` (`0.2.0-alpha`), and tweaks CI runners (`ubuntu-latest` / `ubuntu-latest-m`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957a499e2e88f9853f72bffb605e6952aeac274f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->