### PR TITLE
Fix endianness in field_to_hex / field_from_hex (LE canonical)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.9",
  "halo2curves",
+ "hex",
  "nova-snark",
  "once_cell",
  "reed-solomon-erasure",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Kontor Proof-of-Retrievability (PoR)
 
+> ## ⚠️ BREAKING CHANGE in v(next)
+>
+> `field_to_hex` and `field_from_hex` (in both Rust `kontor-crypto-core` and the npm `kontor-crypto` package) now use the **canonical little-endian** byte order of `ff::PrimeField::to_repr()`, instead of the previous big-endian order.
+>
+> This aligns the hex serialization with what the Kontor indexer (`bytes_to_field_element`) and the `filestorage` contract expect when consuming a field element via WIT. Any hex string of a field element produced by previous versions must be considered invalid (or reversed byte-by-byte) before being read by the new version. The change is binary-equivalent to applying a `byte.reverse()` on the hex output.
+>
+> See commit history for migration details.
+
 [![Crates.io](https://img.shields.io/crates/v/kontor-crypto.svg)](https://crates.io/crates/kontor-crypto)
 [![CI](https://github.com/KontorProtocol/Kontor-Crypto/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/KontorProtocol/Kontor-Crypto/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/KontorProtocol/Kontor-Crypto/blob/main/LICENSE)

--- a/crates/kontor-crypto-core/Cargo.toml
+++ b/crates/kontor-crypto-core/Cargo.toml
@@ -32,3 +32,6 @@ reed-solomon-erasure = "6.0"
 blake2b_simd = "1.0.1"
 constant_time_eq = "0.3.1"
 once_cell = "1.19"
+
+[dev-dependencies]
+hex = "0.4"

--- a/crates/kontor-crypto-core/src/poseidon.rs
+++ b/crates/kontor-crypto-core/src/poseidon.rs
@@ -912,14 +912,14 @@ mod tests {
         assert_eq!(
             poseidon_hash2(Fq::from(0u64), Fq::from(0u64)),
             field_from_hex::<Fq>(
-                "38ec69788c896550d69fb76411058e72798b21bcaaae2ad06101e9dc558b5dbd"
+                "bd5d8b55dce90161d02aaeaabc218b79728e051164b79fd65065898c7869ec38"
             ),
             "poseidon_hash2(0,0) must match Nova"
         );
         assert_eq!(
             poseidon_hash_tagged(domain_tags::leaf(), Fq::from(1u64), Fq::from(2u64)),
             field_from_hex::<Fq>(
-                "2eb3923b358306dc6af5240a87e8ea32ec23a2b4cc99932af880d75a86021495"
+                "951402865ad780f82a9399ccb4a223ec32eae8870a24f56adc0683353b92b32e"
             ),
             "poseidon_hash_tagged(leaf,1,2) must match Nova"
         );

--- a/crates/kontor-crypto-core/src/utils.rs
+++ b/crates/kontor-crypto-core/src/utils.rs
@@ -25,14 +25,18 @@ pub fn field_to_bytes31_le<F: PrimeField>(element: &F) -> [u8; 31] {
     out
 }
 
-/// Render a field element as a lowercase hex string (MSB-first / big-endian),
-/// consistent with [`field_from_hex`].
+/// Render a field element as a lowercase hex string in canonical
+/// `PrimeField::to_repr()` byte order (little-endian for Pallas Fq).
+///
+/// This produces the same output as `hex::encode(f.to_repr())` and is the
+/// inverse of [`field_from_hex`]. The byte order matches what the Kontor
+/// indexer (`bytes_to_field_element`) and the filestorage contract expect
+/// when consuming a `root` field via WIT.
 pub fn field_to_hex<F: PrimeField>(f: &F) -> String {
     use std::fmt::Write;
     let repr = f.to_repr();
     repr.as_ref()
         .iter()
-        .rev()
         .fold(String::with_capacity(64), |mut s, b| {
             let _ = write!(s, "{:02x}", b);
             s
@@ -40,15 +44,61 @@ pub fn field_to_hex<F: PrimeField>(f: &F) -> String {
 }
 
 /// Parse a hex string (optionally `0x`-prefixed) into a field element.
-/// Bytes are interpreted MSB-first and stored in reverse (little-endian repr).
+///
+/// Bytes are interpreted as the canonical `PrimeField::Repr`
+/// (little-endian for Pallas Fq), matching [`field_to_hex`].
 pub fn field_from_hex<F: PrimeField>(hex: &str) -> F {
     let hex = hex.trim_start_matches("0x");
     let mut buf = [0u8; 32];
     for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
         let s = core::str::from_utf8(chunk).expect("hex must be valid UTF-8");
-        buf[31 - i] = u8::from_str_radix(s, 16).expect("hex must contain valid hex digits");
+        buf[i] = u8::from_str_radix(s, 16).expect("hex must contain valid hex digits");
     }
     let mut repr = <F as PrimeField>::Repr::default();
     repr.as_mut().copy_from_slice(&buf);
     F::from_repr(repr).expect("hex value must fit in the field")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2curves::pasta::Fq;
+
+    #[test]
+    fn field_to_hex_matches_hex_encode_to_repr() {
+        // Spec invariant: field_to_hex MUST be byte-equivalent to hex::encode(fe.to_repr()).
+        for i in 0u64..100 {
+            let fe = Fq::from(i.wrapping_mul(2654435761));
+            let via_field_to_hex = field_to_hex(&fe);
+            let via_hex_encode = hex::encode(fe.to_repr());
+            assert_eq!(via_field_to_hex, via_hex_encode, "mismatch at i={i}");
+        }
+    }
+
+    #[test]
+    fn field_to_hex_field_from_hex_round_trip() {
+        for i in 0u64..100 {
+            let fe = Fq::from(i.wrapping_mul(2654435761));
+            let hex = field_to_hex(&fe);
+            let recovered: Fq = field_from_hex(&hex);
+            assert_eq!(fe, recovered, "round-trip failed at i={i}");
+        }
+    }
+
+    #[test]
+    fn field_from_hex_field_to_hex_round_trip() {
+        // hex string round-trip
+        let fe = Fq::from(0x1234_5678_9abc_def0u64);
+        let hex = field_to_hex(&fe);
+        let again = field_to_hex(&field_from_hex::<Fq>(&hex));
+        assert_eq!(hex, again);
+    }
+
+    #[test]
+    fn field_from_hex_accepts_0x_prefix() {
+        let fe = Fq::from(42u64);
+        let hex = field_to_hex(&fe);
+        let prefixed = format!("0x{hex}");
+        assert_eq!(field_from_hex::<Fq>(&prefixed), fe);
+    }
 }

--- a/crates/kontor-crypto-wasm/src/lib.rs
+++ b/crates/kontor-crypto-wasm/src/lib.rs
@@ -297,7 +297,6 @@ mod tests {
         let root_hex_from_bytes: String =
             desc.root
                 .iter()
-                .rev()
                 .fold(String::with_capacity(64), |mut s, b| {
                     use std::fmt::Write;
                     let _ = write!(s, "{:02x}", b);

--- a/crates/kontor-crypto/tests/poseidon_regression.rs
+++ b/crates/kontor-crypto/tests/poseidon_regression.rs
@@ -16,7 +16,7 @@ fn poseidon_hash2_zero_zero() {
     assert_eq!(
         poseidon_hash2(FieldElement::from(0u64), FieldElement::from(0u64)),
         field_from_hex::<FieldElement>(
-            "38ec69788c896550d69fb76411058e72798b21bcaaae2ad06101e9dc558b5dbd"
+            "bd5d8b55dce90161d02aaeaabc218b79728e051164b79fd65065898c7869ec38"
         ),
         "poseidon_hash2(0,0)"
     );
@@ -27,7 +27,7 @@ fn poseidon_hash2_one_two() {
     assert_eq!(
         poseidon_hash2(FieldElement::from(1u64), FieldElement::from(2u64)),
         field_from_hex::<FieldElement>(
-            "041f4c4432174659e6b91ccdc53b7e47caae1cd55c46b5385c13291392283f61"
+            "613f28921329135c38b5465cd51caeca477e3bc5cd1cb9e659461732444c1f04"
         ),
         "poseidon_hash2(1,2)"
     );
@@ -42,7 +42,7 @@ fn poseidon_hash_tagged_leaf_1_2() {
             FieldElement::from(2u64)
         ),
         field_from_hex::<FieldElement>(
-            "2eb3923b358306dc6af5240a87e8ea32ec23a2b4cc99932af880d75a86021495"
+            "951402865ad780f82a9399ccb4a223ec32eae8870a24f56adc0683353b92b32e"
         ),
         "poseidon_hash_tagged(leaf,1,2)"
     );
@@ -57,7 +57,7 @@ fn poseidon_hash_tagged_node_42_123() {
             FieldElement::from(123u64),
         ),
         field_from_hex::<FieldElement>(
-            "3792b290b7368a21134c9fcd2978f2e94c91928442e524b2293ff4d4bbf2772a"
+            "2a77f2bbd4f43f29b224e5428492914ce9f27829cd9f4c13218a36b790b29237"
         ),
         "poseidon_hash_tagged(node,42,123)"
     );

--- a/crates/kontor-crypto/tests/prepare_file_regression.rs
+++ b/crates/kontor-crypto/tests/prepare_file_regression.rs
@@ -29,7 +29,7 @@ fn prepare_file_hello_deterministic() {
 
     assert_eq!(
         field_to_hex(&metadata.root),
-        "073541b34bf621116dd2e6194013c3f5d0242faaf369badb5f535a3b059086f3"
+        "f38690053b5a535fdbba69f3aa2f24d0f5c3134019e6d26d1121f64bb3413507"
     );
 
     assert_eq!(prepared.root, metadata.root);

--- a/packages/kontor-crypto/src/index.ts
+++ b/packages/kontor-crypto/src/index.ts
@@ -60,11 +60,11 @@ export function init(): Promise<void> {
 const HEX: string[] = [];
 for (let i = 0; i < 256; i++) HEX[i] = i.toString(16).padStart(2, "0");
 
-/** Encode a 32-byte field element repr as big-endian hex (MSB-first),
- *  matching Rust `field_to_hex` which iterates `.iter().rev()`. */
+/** Encode a 32-byte field element repr as little-endian hex (canonical
+ *  `PrimeField::to_repr()` order), matching Rust `field_to_hex`. */
 function fieldBytesToHex(bytes: Uint8Array, offset = 0, len = 32): string {
   let hex = "";
-  for (let j = offset + len - 1; j >= offset; j--) hex += HEX[bytes[j]];
+  for (let j = offset; j < offset + len; j++) hex += HEX[bytes[j]];
   return hex;
 }
 


### PR DESCRIPTION
BREAKING: field_to_hex / field_from_hex (Rust + JS) now produce canonical PrimeField::to_repr() little-endian hex instead of big-endian. Aligns with Kontor indexer bytes_to_field_element (from_repr expects LE), fixes ~75% silent failure rate on create-agreement WIT calls. Golden values regenerated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking serialization change: all `field_to_hex`/`field_from_hex` values (and any stored/contract-passed roots) flip byte order, so old hex inputs will decode to different field elements unless migrated. Risk is mitigated by updated golden tests across core, wasm, and JS but still impacts cross-system compatibility.
> 
> **Overview**
> **BREAKING:** Changes `field_to_hex`/`field_from_hex` in Rust and the npm package to use the canonical `ff::PrimeField::to_repr()` byte order (little-endian for Pallas) instead of reversing bytes for big-endian hex.
> 
> Updates dependent expectations and regression fixtures (Poseidon known-answer tests, `prepare_file` golden root, and WASM descriptor/root consistency) to the new hex format, and adds core unit tests asserting `field_to_hex` matches `hex::encode(to_repr())` plus round-trip behavior. Documentation is updated to warn about the endianness change and migration, and `hex` is added as a dev-dependency for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3043c61f3d08c0b204cdacb05c89b2d2f637c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->