### PR TITLE
Fix release action 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Publish kontor-crypto-core
         run: |
           VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "kontor-crypto-core") | .version')
-          if curl -sSfL "https://crates.io/api/v1/crates/kontor-crypto-core/$VERSION" | jq -e '.version' >/dev/null 2>&1; then
+          if curl -sSfL -A "kontor-crypto-release-workflow (github.com/${{ github.repository }})" \
+              "https://index.crates.io/ko/nt/kontor-crypto-core" \
+              | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null 2>&1; then
             echo "kontor-crypto-core@$VERSION already published, skipping."
             exit 0
           fi
@@ -38,7 +40,9 @@ jobs:
           VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "kontor-crypto-core") | .version')
           echo "Waiting for kontor-crypto-core@$VERSION to appear on crates.io..."
           for i in $(seq 1 30); do
-            if curl -sSfL "https://crates.io/api/v1/crates/kontor-crypto-core/$VERSION" | jq -e '.version' >/dev/null 2>&1; then
+            if curl -sSfL -A "kontor-crypto-release-workflow (github.com/${{ github.repository }})" \
+                "https://index.crates.io/ko/nt/kontor-crypto-core" \
+                | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null 2>&1; then
               echo "kontor-crypto-core@$VERSION is indexed"
               exit 0
             fi
@@ -51,7 +55,9 @@ jobs:
       - name: Publish kontor-crypto
         run: |
           VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "kontor-crypto") | .version')
-          if curl -sSfL "https://crates.io/api/v1/crates/kontor-crypto/$VERSION" | jq -e '.version' >/dev/null 2>&1; then
+          if curl -sSfL -A "kontor-crypto-release-workflow (github.com/${{ github.repository }})" \
+              "https://index.crates.io/ko/nt/kontor-crypto" \
+              | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null 2>&1; then
             echo "kontor-crypto@$VERSION already published, skipping."
             exit 0
           fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions release checks to query the crates.io index instead of the crates.io API, which may affect publish skip/timeout behavior but doesn’t change shipped code.
> 
> **Overview**
> Updates the Release GitHub Action to detect whether `kontor-crypto-core` and `kontor-crypto` versions are already published by querying the crates.io index (`https://index.crates.io/...`) and filtering on `.vers`, instead of hitting the crates.io API version endpoint.
> 
> Adds a custom `curl` User-Agent and applies the same index-based check to the post-publish “wait for indexing” loop, aiming to make release publishing/skip logic more reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dee3cb8fa9f7c38662a3924cb9e61a8b1e602e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->