### PR TITLE
fix(circuit): strict bit-decomposition for path indices (#46)

### DIFF
--- a/crates/kontor-crypto/src/circuit/synth.rs
+++ b/crates/kontor-crypto/src/circuit/synth.rs
@@ -362,7 +362,13 @@ fn synthesize_por_circuit_impl<F: PrimeField + PrimeFieldBits, CS: ConstraintSys
         // 3. Get binary decomposition of challenge and extract path bits
         let index_bits = {
             let mut bits_ns = file_cs.namespace(|| "challenge_with_idx_bits");
-            challenge_with_idx.to_bits_le(&mut bits_ns)?
+            // STRICT decomposition: enforce the canonical in-field bit
+            // representation. The low bits become Merkle path-selection indices,
+            // and non-strict `to_bits_le` admits a second (value + p)
+            // decomposition (the field modulus is just above 2^254, NUM_BITS=255),
+            // whose low bits encode index+1 — letting a prover open a leaf other
+            // than the challenged one. See Kontor-Crypto issue #46.
+            challenge_with_idx.to_bits_le_strict(&mut bits_ns)?
         };
         // Build exactly file_tree_depth bits, allocating false for padding (not constants!)
         let mut file_path_indices: Vec<Boolean> = Vec::with_capacity(file_tree_depth);
@@ -586,7 +592,12 @@ fn synthesize_por_circuit_impl<F: PrimeField + PrimeFieldBits, CS: ConstraintSys
             // Decompose public ledger index to bits for Merkle path verification
             let ledger_index_bits = {
                 let mut bits_ns = file_cs.namespace(|| "ledger_index_bits");
-                ledger_index_public.to_bits_le(&mut bits_ns)?
+                // STRICT decomposition (see issue #46): the verifier range-checks
+                // the public ledger-index scalar but not its in-circuit bit
+                // decomposition, so non-strict `to_bits_le` would let a prover
+                // steer the aggregation path to index+1 while the public scalar
+                // stays index.
+                ledger_index_public.to_bits_le_strict(&mut bits_ns)?
             };
 
             // Take only the bits needed for aggregated tree depth


### PR DESCRIPTION
Closes #46.

The Merkle path-selection indices were derived with the non-strict `to_bits_le`, which only enforces `Σ bitᵢ·2ⁱ ≡ x (mod p)` — not canonicity. Because the Pallas scalar modulus sits just above 2²⁵⁴ while `NUM_BITS = 255` (and `p ≡ 1 mod 2³²`), nearly every value admits a second valid 255-bit decomposition `x + p` whose low bits encode `index + 1`. A malicious prover could witness that to open leaf `idx+1` instead of the challenged `idx` (file tree), or steer the aggregation path to `index+1` while the public scalar stays `index`.

Fix: the two index-derivation sites in the **production** circuit (`synth.rs` — `challenge_with_idx` and `ledger_index_public`) now use `to_bits_le_strict`, which enforces the canonical in-field representation. Completeness is preserved (honest values are canonical); the idx+1 opening is closed.

The non-index `depth_public` decomposition is intentionally left as `to_bits_le` — it feeds active-flag/depth gating, not a path index, so it is not exploitable (per the audit).

**Verified:** build + `api_functionality`, `circuit_wiring`, `depth_zero_cheat_regression`, and `security_{malicious_prover,challenge_distribution,ledger,negative_cases}` all pass.

The constant-size circuit variant (`formal_components.rs`) has the same pattern; the matching fix is pushed to the #44 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Directly patches a malicious-prover soundness issue in proof-of-retrievability path verification; incorrect constraints would break cryptographic guarantees.
> 
> **Overview**
> Closes a soundness gap in the production Nova PoR circuit (`synth.rs`) where Merkle **path-selection bits** were derived with non-strict little-endian decomposition.
> 
> **`challenge_with_idx`** (file-tree path) and **`ledger_index_public`** (aggregation path) now use **`to_bits_le_strict`**, so the low bits used as indices are the canonical in-field representation. Non-strict decomposition only enforces congruence mod *p*; with a 255-bit width and modulus just above 2²⁵⁴, a prover could witness an alternate decomposition whose low bits encode **index+1**, opening the wrong file leaf or steering the aggregation path while public scalars still match the challenged index.
> 
> **`depth_public`** remains on **`to_bits_le`** because it drives depth gating, not path indices (not treated as exploitable here). Comments reference issue #46.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d7dea282319b678e48898bbb99df2ed41b7375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->