### PR TITLE
docs: drop unaudited framing from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![CI](https://github.com/KontorProtocol/Kontor-Crypto/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/KontorProtocol/Kontor-Crypto/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/KontorProtocol/Kontor-Crypto/blob/main/LICENSE)
 
-> **⚠️ WARNING: This code is unaudited and experimental. Use at your own risk.**
+> **⚠️ WARNING: This code is experimental and pre-release. Use at your own risk.**
 
 This project implements a Proof-of-Retrievability (PoR) system designed to provide economically enforceable guarantees that Storage Nodes are actually storing the data they have committed to. It is a core component for decentralized storage metaprotocols where a network of Indexers (Verifiers) must continuously audit Storage Nodes (Provers).
 


### PR DESCRIPTION
Rewords the README warning to drop the "unaudited" framing (consistent with the Kontor repo).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no code or security behavior impact.
> 
> **Overview**
> Updates the README disclaimer to match the main Kontor repo: it no longer calls the code **unaudited**, and instead describes it as **experimental and pre-release** while keeping the same “use at your own risk” warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274c34ecd0158f0e42123c9d7d8364d8feab9472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->