### PR TITLE
Add stateless PoR verification (verify_stateless + aggregate_root)

### DIFF
--- a/crates/kontor-crypto/src/api/mod.rs
+++ b/crates/kontor-crypto/src/api/mod.rs
@@ -78,6 +78,11 @@ pub use types::{
     Challenge, ChallengeID, FieldElement, FileMetadata, KeyPair, PorParams, PreparedFile, Proof,
 };
 
+// Stateless verification: verify a proof from bare ledger data (just the valid-root
+// set) instead of a live `FileLedger`. For hosts that keep the file registry in
+// contract storage.
+pub use verify::{verify_stateless, LedgerView, StatelessLedger};
+
 // Internal modules can access these for implementation
 // Export for testing - these are implementation details
 #[doc(hidden)]

--- a/crates/kontor-crypto/src/api/plan.rs
+++ b/crates/kontor-crypto/src/api/plan.rs
@@ -4,6 +4,7 @@
 //! by handling all the common preprocessing steps in one place.
 
 use super::types::{Challenge, FieldElement};
+use crate::poseidon::calculate_root_commitment;
 use crate::{config, ledger::FileLedger, KontorPoRError, Result};
 use ff::Field;
 use sha2::{Digest, Sha256};
@@ -142,6 +143,76 @@ impl Plan {
             initial_state,
             sorted_challenges,
             ledger_indices,
+            depths,
+            seeds,
+            expected_rcs,
+            public_io_layout,
+        })
+    }
+
+    /// Build a [`Plan`] for VERIFICATION from the challenges alone, with no ledger.
+    ///
+    /// Verification feeds `proof.ledger_root` and `proof.ledger_indices` to the
+    /// circuit as public inputs (see `verify`), so the ledger-derived plan fields
+    /// — `aggregated_root`, `aggregated_tree_depth`, `ledger_indices` — are never
+    /// read on the verify path; they are filled with placeholders here. The
+    /// per-file metadata binding (registered `rc` vs `expected_rc`) is done by the
+    /// caller against a `LedgerView`, so this performs no lookups.
+    pub(crate) fn for_verify(challenges: &[Challenge]) -> Result<Plan> {
+        if challenges.is_empty() {
+            return Err(KontorPoRError::InvalidInput(
+                "Cannot create plan from empty challenges".to_string(),
+            ));
+        }
+
+        for challenge in challenges {
+            challenge.validate()?;
+        }
+
+        let max_file_depth = challenges
+            .iter()
+            .map(|c| crate::api::tree_depth_from_metadata(&c.file_metadata))
+            .max()
+            .unwrap_or(0);
+        let (files_per_step, file_tree_depth) =
+            config::derive_shape(challenges.len(), max_file_depth);
+
+        // Same canonical ordering as `make_plan` so depths/seeds/expected_rcs line
+        // up with the proof's `ledger_indices`.
+        let mut sorted_challenges: Vec<Challenge> = challenges.to_vec();
+        sorted_challenges.sort_by(|a, b| {
+            match a.file_metadata.file_id.cmp(&b.file_metadata.file_id) {
+                Ordering::Equal => a.id().0.cmp(&b.id().0),
+                other => other,
+            }
+        });
+
+        let initial_state = derive_initial_state(&sorted_challenges);
+
+        let mut expected_rcs = vec![FieldElement::ZERO; files_per_step];
+        let mut depths = vec![0usize; files_per_step];
+        let mut seeds = vec![FieldElement::ZERO; files_per_step];
+        for (i, challenge) in sorted_challenges.iter().enumerate() {
+            let file_depth = crate::api::tree_depth_from_metadata(&challenge.file_metadata);
+            expected_rcs[i] = calculate_root_commitment(
+                challenge.file_metadata.root,
+                FieldElement::from(file_depth as u64),
+            );
+            depths[i] = file_depth;
+            seeds[i] = challenge.seed;
+        }
+
+        let public_io_layout = config::PublicIOLayout::new(files_per_step);
+
+        Ok(Plan {
+            files_per_step,
+            file_tree_depth,
+            // Placeholders: verify reads these from the proof, not the plan.
+            aggregated_tree_depth: 0,
+            aggregated_root: FieldElement::ZERO,
+            initial_state,
+            sorted_challenges,
+            ledger_indices: vec![0usize; files_per_step],
             depths,
             seeds,
             expected_rcs,

--- a/crates/kontor-crypto/src/api/plan.rs
+++ b/crates/kontor-crypto/src/api/plan.rs
@@ -38,9 +38,29 @@ pub(crate) struct Plan {
     pub(crate) public_io_layout: config::PublicIOLayout,
 }
 
+/// Where the three aggregation public inputs come from — the only fields whose
+/// source differs between proving and verification. The prover derives them from
+/// the ledger's aggregated tree; the verifier takes them from the proof, where they
+/// were committed and are SNARK-bound. Every other plan field is derived from the
+/// challenges alone, identically on both paths — so one `make_plan` serves both and
+/// `build_z0_primary` is uniform.
+pub(crate) enum AggInputs<'a> {
+    /// Prove path: derive root/depth/indices from the live ledger, cross-checking
+    /// each file's registered `rc` against the challenge metadata.
+    Ledger(&'a FileLedger),
+    /// Verify path: the values already committed in (and SNARK-bound by) the proof.
+    Proof {
+        root: FieldElement,
+        aggregated_tree_depth: usize,
+        ledger_indices: Vec<usize>,
+    },
+}
+
 impl Plan {
-    /// Create a unified preprocessing plan for both prove() and verify().
-    pub(crate) fn make_plan(challenges: &[Challenge], ledger: &FileLedger) -> Result<Plan> {
+    /// The single preprocessing plan shared by `prove()` and `verify()`. Every
+    /// challenge-derived field is computed once here; only the three aggregation
+    /// public inputs vary by source (see [`AggInputs`]).
+    pub(crate) fn make_plan(challenges: &[Challenge], agg: AggInputs) -> Result<Plan> {
         if challenges.is_empty() {
             return Err(KontorPoRError::InvalidInput(
                 "Cannot create plan from empty challenges".to_string(),
@@ -51,18 +71,7 @@ impl Plan {
             challenge.validate()?;
         }
 
-        // Derive aggregated root internally based on number of challenges
-        // Single challenge = single-file proof (use file root)
-        // Multiple challenges = multi-file proof (use ledger root)
-        let aggregated_root = if challenges.len() > 1 {
-            // Multi-file case: use ledger root
-            ledger.tree.root()
-        } else {
-            // Single-file case: always use file root (even if ledger is provided)
-            challenges[0].file_metadata.root
-        };
-
-        // 1. Derive shape from challenges
+        // 1. Derive shape from challenges.
         let max_file_depth = challenges
             .iter()
             .map(|c| crate::api::tree_depth_from_metadata(&c.file_metadata))
@@ -70,13 +79,8 @@ impl Plan {
             .unwrap_or(0);
         let (files_per_step, file_tree_depth) =
             config::derive_shape(challenges.len(), max_file_depth);
-        let aggregated_tree_depth = if files_per_step > 1 {
-            ledger.tree.layers.len() - 1
-        } else {
-            0
-        };
 
-        // 2. Sort challenges canonically by (file_id, challenge_id)
+        // 2. Sort challenges canonically by (file_id, challenge_id).
         //
         // We need a total order so proof verification cannot accidentally depend on
         // the caller-provided ordering of `challenges` when multiple challenges refer
@@ -93,102 +97,7 @@ impl Plan {
         // non-circuit fields captured by Challenge::id()).
         let initial_state = derive_initial_state(&sorted_challenges);
 
-        // 3. Compute ledger indices
-        let mut ledger_indices = vec![0usize; files_per_step];
-        let mut expected_rcs = vec![FieldElement::ZERO; files_per_step];
-        use crate::poseidon::calculate_root_commitment;
-
-        for (i, challenge) in sorted_challenges.iter().enumerate() {
-            let file_depth = crate::api::tree_depth_from_metadata(&challenge.file_metadata);
-            let expected_rc = calculate_root_commitment(
-                challenge.file_metadata.root,
-                FieldElement::from(file_depth as u64),
-            );
-            expected_rcs[i] = expected_rc;
-
-            let (ledger_idx, actual_rc) = ledger
-                .lookup(&challenge.file_metadata.file_id)
-                .ok_or_else(|| KontorPoRError::FileNotInLedger {
-                    file_id: challenge.file_metadata.file_id.clone(),
-                })?;
-
-            if actual_rc != expected_rc {
-                return Err(KontorPoRError::MetadataMismatch);
-            }
-
-            ledger_indices[i] = ledger_idx;
-        }
-
-        // Compute actual depths for each challenge
-        let mut depths = vec![0usize; files_per_step];
-        for (i, challenge) in sorted_challenges.iter().enumerate() {
-            let depth = crate::api::tree_depth_from_metadata(&challenge.file_metadata);
-            depths[i] = depth;
-        }
-
-        // Collect seeds for each challenge
-        let mut seeds = vec![FieldElement::ZERO; files_per_step];
-        for (i, challenge) in sorted_challenges.iter().enumerate() {
-            seeds[i] = challenge.seed;
-        }
-
-        // 4. Create public I/O layout helper
-        let public_io_layout = config::PublicIOLayout::new(files_per_step);
-
-        Ok(Plan {
-            files_per_step,
-            file_tree_depth,
-            aggregated_tree_depth,
-            aggregated_root,
-            initial_state,
-            sorted_challenges,
-            ledger_indices,
-            depths,
-            seeds,
-            expected_rcs,
-            public_io_layout,
-        })
-    }
-
-    /// Build a [`Plan`] for VERIFICATION from the challenges alone, with no ledger.
-    ///
-    /// Verification feeds `proof.ledger_root` and `proof.ledger_indices` to the
-    /// circuit as public inputs (see `verify`), so the ledger-derived plan fields
-    /// — `aggregated_root`, `aggregated_tree_depth`, `ledger_indices` — are never
-    /// read on the verify path; they are filled with placeholders here. The
-    /// per-file metadata binding (registered `rc` vs `expected_rc`) is done by the
-    /// caller against a `LedgerView`, so this performs no lookups.
-    pub(crate) fn for_verify(challenges: &[Challenge]) -> Result<Plan> {
-        if challenges.is_empty() {
-            return Err(KontorPoRError::InvalidInput(
-                "Cannot create plan from empty challenges".to_string(),
-            ));
-        }
-
-        for challenge in challenges {
-            challenge.validate()?;
-        }
-
-        let max_file_depth = challenges
-            .iter()
-            .map(|c| crate::api::tree_depth_from_metadata(&c.file_metadata))
-            .max()
-            .unwrap_or(0);
-        let (files_per_step, file_tree_depth) =
-            config::derive_shape(challenges.len(), max_file_depth);
-
-        // Same canonical ordering as `make_plan` so depths/seeds/expected_rcs line
-        // up with the proof's `ledger_indices`.
-        let mut sorted_challenges: Vec<Challenge> = challenges.to_vec();
-        sorted_challenges.sort_by(|a, b| {
-            match a.file_metadata.file_id.cmp(&b.file_metadata.file_id) {
-                Ordering::Equal => a.id().0.cmp(&b.id().0),
-                other => other,
-            }
-        });
-
-        let initial_state = derive_initial_state(&sorted_challenges);
-
+        // 3. Per-slot vectors derived from the challenges alone (no ledger needed).
         let mut expected_rcs = vec![FieldElement::ZERO; files_per_step];
         let mut depths = vec![0usize; files_per_step];
         let mut seeds = vec![FieldElement::ZERO; files_per_step];
@@ -202,21 +111,57 @@ impl Plan {
             seeds[i] = challenge.seed;
         }
 
-        let public_io_layout = config::PublicIOLayout::new(files_per_step);
+        // 4. The three aggregation public inputs, by source. This is the ONLY thing
+        //    that differs between proving and verification.
+        let (aggregated_root, aggregated_tree_depth, ledger_indices) = match agg {
+            AggInputs::Ledger(ledger) => {
+                // Single-file uses the file's own root; multi-file uses the ledger root.
+                let aggregated_root = if sorted_challenges.len() > 1 {
+                    ledger.tree.root()
+                } else {
+                    sorted_challenges[0].file_metadata.root
+                };
+                let aggregated_tree_depth = if files_per_step > 1 {
+                    ledger.tree.layers.len() - 1
+                } else {
+                    0
+                };
+                // Each file's index, cross-checking the registered `rc` against the
+                // challenge metadata (the prove-time registry binding).
+                let mut ledger_indices = vec![0usize; files_per_step];
+                for (i, challenge) in sorted_challenges.iter().enumerate() {
+                    let (ledger_idx, actual_rc) =
+                        ledger
+                            .lookup(&challenge.file_metadata.file_id)
+                            .ok_or_else(|| KontorPoRError::FileNotInLedger {
+                                file_id: challenge.file_metadata.file_id.clone(),
+                            })?;
+                    if actual_rc != expected_rcs[i] {
+                        return Err(KontorPoRError::MetadataMismatch);
+                    }
+                    ledger_indices[i] = ledger_idx;
+                }
+                (aggregated_root, aggregated_tree_depth, ledger_indices)
+            }
+            AggInputs::Proof {
+                root,
+                aggregated_tree_depth,
+                ledger_indices,
+            } => (root, aggregated_tree_depth, ledger_indices),
+        };
 
         Ok(Plan {
             files_per_step,
             file_tree_depth,
-            // Placeholders: verify reads these from the proof, not the plan.
-            aggregated_tree_depth: 0,
-            aggregated_root: FieldElement::ZERO,
+            aggregated_tree_depth,
+            aggregated_root,
             initial_state,
             sorted_challenges,
-            ledger_indices: vec![0usize; files_per_step],
+            ledger_indices,
             depths,
             seeds,
             expected_rcs,
-            public_io_layout,
+            public_io_layout: config::PublicIOLayout::new(files_per_step),
         })
     }
 

--- a/crates/kontor-crypto/src/api/prove.rs
+++ b/crates/kontor-crypto/src/api/prove.rs
@@ -4,7 +4,7 @@
 //! broken down into focused, manageable functions.
 
 use super::{
-    plan::Plan,
+    plan::{AggInputs, Plan},
     types::{Challenge, FieldElement, PorParams, PreparedFile, Proof},
     witness::generate_circuit_witness,
 };
@@ -161,7 +161,7 @@ fn setup_proving_environment(
     }
 
     // Create unified preprocessing plan
-    let plan = Plan::make_plan(challenges, ledger)?;
+    let plan = Plan::make_plan(challenges, AggInputs::Ledger(ledger))?;
 
     // Load or generate parameters for the exact shape
     let params = crate::params::load_or_generate_params(

--- a/crates/kontor-crypto/src/api/verify.rs
+++ b/crates/kontor-crypto/src/api/verify.rs
@@ -4,7 +4,7 @@
 //! secure root derivation from the ledger.
 
 use super::{
-    plan::Plan,
+    plan::{AggInputs, Plan},
     types::{Challenge, FieldElement, Proof},
 };
 use crate::{config, ledger::FileLedger, KontorPoRError, Result};
@@ -170,9 +170,17 @@ fn verify_with(challenges: &[Challenge], proof: &Proof, ledger: &impl LedgerView
         return Ok(false);
     }
 
-    // Build the verify-side plan from the challenges alone: the circuit's public
-    // inputs come from the proof, so no ledger/tree is needed to construct it.
-    let plan = Plan::for_verify(challenges)?;
+    // Build the verify-side plan: every challenge-derived field comes from the
+    // challenges; the three aggregation public inputs come from the proof (where
+    // they were committed and are SNARK-bound), so no ledger/tree is needed.
+    let plan = Plan::make_plan(
+        challenges,
+        AggInputs::Proof {
+            root: proof.ledger_root,
+            aggregated_tree_depth: proof.aggregated_tree_depth,
+            ledger_indices: proof.ledger_indices.clone(),
+        },
+    )?;
 
     // Per-file metadata binding (delegated to the view): for a `FileLedger` this
     // confirms each challenged file is registered with a matching root-commitment;
@@ -303,15 +311,9 @@ fn verify_with(challenges: &[Challenge], proof: &Proof, ledger: &impl LedgerView
     debug!("  - Using proof.ledger_indices: {:?}", proof.ledger_indices);
     debug!("  - Depths from challenges: {:?}", plan.depths);
 
-    // Build z0_primary with proof's values for root/indices
-    let z0_primary = plan.public_io_layout.build_z0_primary(
-        proof.ledger_root,
-        plan.initial_state,
-        &proof.ledger_indices,
-        &plan.depths,
-        &plan.seeds,
-        &plan.expected_rcs,
-    );
+    // Build z0_primary uniformly — the plan already carries the proof's
+    // root/indices (via `AggInputs::Proof`), so this is the same call the prover makes.
+    let z0_primary = plan.build_z0_primary();
     debug!("VERIFIER z0_primary: {:?}", z0_primary);
 
     let num_iterations = plan.sorted_challenges[0].num_challenges;

--- a/crates/kontor-crypto/src/api/verify.rs
+++ b/crates/kontor-crypto/src/api/verify.rs
@@ -5,11 +5,66 @@
 
 use super::{
     plan::Plan,
-    types::{Challenge, Proof},
+    types::{Challenge, FieldElement, Proof},
 };
 use crate::{config, ledger::FileLedger, KontorPoRError, Result};
+use ff::PrimeField;
 use std::collections::HashSet;
 use tracing::{debug, info_span};
+
+/// What proof verification needs from "the ledger". Verification consumes
+/// `proof.ledger_root` and `proof.ledger_indices` as the circuit's public inputs,
+/// so it never needs the live aggregated Merkle tree — only the set of valid
+/// aggregated roots. This lets verification run either against a full
+/// [`FileLedger`] (the prover's view) or against bare data held elsewhere — e.g. a
+/// contract's own storage — via [`StatelessLedger`].
+pub trait LedgerView {
+    /// Whether `root` is an accepted aggregated ledger root (current or historical).
+    fn is_valid_root(&self, root: FieldElement) -> bool;
+
+    /// Per-file metadata binding: confirm the challenged file is registered with a
+    /// root-commitment matching the challenge's claimed metadata. The default
+    /// accepts — for a view that *is* the registry (a contract that builds
+    /// challenges from its own storage), this cross-check is vacuous, and "is the
+    /// file registered?" is enforced by the caller before verification.
+    fn check_registered(&self, _file_id: &str, _expected_rc: FieldElement) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl LedgerView for FileLedger {
+    fn is_valid_root(&self, root: FieldElement) -> bool {
+        FileLedger::is_valid_root(self, root)
+    }
+    fn check_registered(&self, file_id: &str, expected_rc: FieldElement) -> Result<()> {
+        match self.files.get(file_id).map(|entry| entry.rc) {
+            None => Err(KontorPoRError::FileNotInLedger {
+                file_id: file_id.to_string(),
+            }),
+            Some(actual_rc) if actual_rc != expected_rc => Err(KontorPoRError::MetadataMismatch),
+            Some(_) => Ok(()),
+        }
+    }
+}
+
+/// A [`LedgerView`] backed by plain data instead of a live [`FileLedger`]: just the
+/// set of valid aggregated roots. That is exactly the data a contract holds in its
+/// own storage once the file registry moves in-contract, so the host can verify
+/// proofs without maintaining an accumulator. The per-file metadata cross-check is
+/// skipped (see [`LedgerView::check_registered`]) — the contract is the registry,
+/// so it builds challenges from its own files and checks existence itself.
+pub struct StatelessLedger<'a> {
+    /// Accepted aggregated roots ({current} ∪ historical), each as the 32-byte
+    /// little-endian field repr (matching `FileLedger::historical_roots`).
+    pub valid_roots: &'a HashSet<[u8; 32]>,
+}
+
+impl LedgerView for StatelessLedger<'_> {
+    fn is_valid_root(&self, root: FieldElement) -> bool {
+        let repr: [u8; 32] = root.to_repr().into();
+        self.valid_roots.contains(&repr)
+    }
+}
 
 /// Verifies a proof against one or more challenges.
 ///
@@ -49,6 +104,26 @@ use tracing::{debug, info_span};
 /// Returns `Ok(true)` if the proof is valid, `Ok(false)` if invalid, or an error
 /// if verification fails due to invalid inputs, invalid ledger root, or unexpected errors.
 pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> Result<bool> {
+    verify_with(challenges, proof, ledger)
+}
+
+/// Verify a proof against challenges using bare ledger data instead of a live
+/// [`FileLedger`] — just the set of valid aggregated roots. Behaves identically to
+/// [`verify`] except it skips the per-file metadata cross-check (see
+/// [`StatelessLedger`]).
+///
+/// This is the entry point for hosts that keep the file registry in contract
+/// storage rather than an in-memory accumulator.
+pub fn verify_stateless(
+    challenges: &[Challenge],
+    proof: &Proof,
+    valid_roots: &HashSet<[u8; 32]>,
+) -> Result<bool> {
+    let view = StatelessLedger { valid_roots };
+    verify_with(challenges, proof, &view)
+}
+
+fn verify_with(challenges: &[Challenge], proof: &Proof, ledger: &impl LedgerView) -> Result<bool> {
     let _span = info_span!(
         "verify",
         num_challenges = challenges.len(),
@@ -95,8 +170,17 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
         return Ok(false);
     }
 
-    // Create unified preprocessing plan (derives root internally for security)
-    let plan = Plan::make_plan(challenges, ledger)?;
+    // Build the verify-side plan from the challenges alone: the circuit's public
+    // inputs come from the proof, so no ledger/tree is needed to construct it.
+    let plan = Plan::for_verify(challenges)?;
+
+    // Per-file metadata binding (delegated to the view): for a `FileLedger` this
+    // confirms each challenged file is registered with a matching root-commitment;
+    // for a stateless view it is a no-op (the contract is the registry). In
+    // `make_plan` this lived inside the ledger lookup loop.
+    for (i, challenge) in plan.sorted_challenges.iter().enumerate() {
+        ledger.check_registered(&challenge.file_metadata.file_id, plan.expected_rcs[i])?;
+    }
 
     // --- Proof shape + index sanity checks ---
     //
@@ -155,9 +239,8 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
     // historical root. For single-file proofs, the circuit uses the file's root directly.
     if is_multi_file && !ledger.is_valid_root(proof.ledger_root) {
         debug!(
-            "Proof ledger_root {:?} is not in ledger's valid roots (current: {:?})",
+            "Proof ledger_root {:?} is not in the ledger's set of valid roots",
             proof.ledger_root,
-            ledger.root()
         );
         return Err(KontorPoRError::InvalidLedgerRoot {
             proof_root: format!("{:?}", proof.ledger_root),
@@ -237,7 +320,7 @@ pub fn verify(challenges: &[Challenge], proof: &Proof, ledger: &FileLedger) -> R
     tracing::Span::current().record("num_iterations", num_iterations);
     tracing::Span::current().record("files_per_step", plan.files_per_step);
 
-    if plan.aggregated_tree_depth == 0 {
+    if !is_multi_file {
         debug!("verify() - Single-file verification:");
     } else {
         debug!("verify() - Multi-file verification:");

--- a/crates/kontor-crypto/src/ledger.rs
+++ b/crates/kontor-crypto/src/ledger.rs
@@ -19,7 +19,7 @@ use crate::merkle::{build_tree_from_leaves, get_padded_proof_for_leaf, MerkleTre
 use crate::poseidon::calculate_root_commitment;
 use crate::KontorPoRError;
 use bincode::Options;
-use ff::Field;
+use ff::{Field, PrimeField};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
@@ -427,6 +427,38 @@ impl FileLedger {
             }
         }
     }
+}
+
+/// Compute the aggregated ledger root from file root-commitments (`rc`s) alone,
+/// statelessly — no live [`FileLedger`] required.
+///
+/// `rcs` MUST be in the ledger's canonical order: lexicographic by `file_id`
+/// (the same order a `BTreeMap<String, _>` iterates, and the order an
+/// order-preserving key codec yields for string keys). The result is byte-for-byte
+/// identical to [`FileLedger::root`] over the same file set (this mirrors
+/// `rebuild_tree`), so a contract holding its files in `file_id` order can compute
+/// the current ledger root itself and feed it to `verify_stateless` as a valid root.
+pub fn aggregate_root(rcs: &[F]) -> Result<[u8; 32], KontorPoRError> {
+    let tree = if rcs.is_empty() {
+        // An empty ledger has a tree with a single zero leaf (see `rebuild_tree`).
+        build_tree_from_leaves(&[F::ZERO])?
+    } else {
+        let padded_len = rcs.len().next_power_of_two();
+        let mut padded = rcs.to_vec();
+        padded.resize(padded_len, F::ZERO);
+        build_tree_from_leaves(&padded)?
+    };
+    Ok(tree.root().to_repr().into())
+}
+
+/// Convenience over [`aggregate_root`] that takes each file's `(root, depth)` and
+/// computes the `rc`s internally. `files` MUST be in canonical `file_id` order.
+pub fn aggregate_root_from_files(files: &[(F, usize)]) -> Result<[u8; 32], KontorPoRError> {
+    let rcs: Vec<F> = files
+        .iter()
+        .map(|(root, depth)| calculate_root_commitment(*root, F::from(*depth as u64)))
+        .collect();
+    aggregate_root(&rcs)
 }
 
 #[cfg(test)]

--- a/crates/kontor-crypto/src/lib.rs
+++ b/crates/kontor-crypto/src/lib.rs
@@ -95,10 +95,14 @@ pub mod utils;
 
 // Re-export commonly used types and functions for convenience
 pub use api::{prepare_file, reconstruct_file, tree_depth_from_metadata, PorSystem};
-pub use api::{Challenge, FieldElement, FileMetadata, PorParams, PreparedFile, Proof};
+pub use api::{
+    verify_stateless, Challenge, FieldElement, FileMetadata, PorParams, PreparedFile, Proof,
+};
 pub use circuit::{CircuitWitness, FileProofWitness, PorCircuit};
 pub use error::{KontorPoRError, Result};
-pub use ledger::{FileDescriptor, FileLedger, HistoricalRootPolicy};
+pub use ledger::{
+    aggregate_root, aggregate_root_from_files, FileDescriptor, FileLedger, HistoricalRootPolicy,
+};
 pub use merkle::{
     build_tree, build_tree_from_leaves, get_leaf_hash, get_padded_proof_for_leaf, hash_leaf_data,
     hash_node, verify_merkle_proof_in_place, CircuitMerkleProof, MerkleTree,

--- a/crates/kontor-crypto/tests/stateless_verify.rs
+++ b/crates/kontor-crypto/tests/stateless_verify.rs
@@ -1,0 +1,81 @@
+//! Stateless verification equivalence.
+//!
+//! `verify_stateless` must accept/reject exactly what the ledger-based `verify`
+//! does, sourcing its single fact — the valid-root set — from plain data instead
+//! of a live `FileLedger`. And `aggregate_root` must reproduce `FileLedger::root`
+//! byte-for-byte so a contract can compute the current ledger root itself.
+//!
+//! The stateless path intentionally skips the per-file metadata cross-check (the
+//! contract is the registry and checks file existence itself), so the binding for
+//! a multi-file proof is valid-root membership + the SNARK.
+
+mod common;
+use common::fixtures::{setup_test_scenario, TestConfig};
+
+use ff::PrimeField;
+use kontor_crypto::api::{verify_stateless, FieldElement, PorSystem};
+use kontor_crypto::ledger::FileLedger;
+use kontor_crypto::{aggregate_root, aggregate_root_from_files, KontorPoRError};
+use std::collections::HashSet;
+
+/// Derive the stateless verifier's input from a populated ledger — the set of
+/// valid aggregated roots a contract would hold in its own storage.
+fn valid_roots(ledger: &FileLedger) -> HashSet<[u8; 32]> {
+    let mut roots: HashSet<[u8; 32]> = ledger.historical_roots.iter().copied().collect();
+    roots.insert(ledger.root().to_repr().into());
+    roots
+}
+
+#[test]
+fn stateless_matches_ledger_multi_file() {
+    let setup = setup_test_scenario(&TestConfig::multi_file(2)).unwrap();
+    let ledger = setup.ledger_ref().unwrap();
+    let system = PorSystem::new(ledger);
+    let files: Vec<&_> = setup.file_refs().values().copied().collect();
+    let proof = system.prove(files, &setup.challenges).unwrap();
+
+    // Ground truth: ledger-based verify accepts.
+    assert!(system.verify(&proof, &setup.challenges).unwrap());
+
+    let roots = valid_roots(ledger);
+
+    // Equivalence: stateless verify accepts the same proof.
+    assert!(
+        verify_stateless(&setup.challenges, &proof, &roots).unwrap(),
+        "stateless verify must accept what ledger verify accepts"
+    );
+
+    // aggregate_root reproduces the ledger root exactly (rc and (root,depth) forms).
+    let expected: [u8; 32] = ledger.root().to_repr().into();
+    let rcs: Vec<FieldElement> = ledger.files.values().map(|e| e.rc).collect();
+    assert_eq!(aggregate_root(&rcs).unwrap(), expected);
+    let files_rd: Vec<(FieldElement, usize)> =
+        ledger.files.values().map(|e| (e.root, e.depth)).collect();
+    assert_eq!(aggregate_root_from_files(&files_rd).unwrap(), expected);
+
+    // Negative: a valid-root set missing the proof's root → reject (multi-file).
+    let no_roots = HashSet::new();
+    assert!(matches!(
+        verify_stateless(&setup.challenges, &proof, &no_roots),
+        Err(KontorPoRError::InvalidLedgerRoot { .. })
+    ));
+}
+
+#[test]
+fn stateless_matches_ledger_single_file() {
+    let setup = setup_test_scenario(&TestConfig::default()).unwrap();
+    let ledger = setup.ledger_ref().unwrap();
+    let system = PorSystem::new(ledger);
+    let files: Vec<&_> = setup.file_refs().values().copied().collect();
+    let proof = system.prove(files, &setup.challenges).unwrap();
+
+    assert!(system.verify(&proof, &setup.challenges).unwrap());
+
+    let roots = valid_roots(ledger);
+    assert!(verify_stateless(&setup.challenges, &proof, &roots).unwrap());
+
+    // Single-file proofs skip the ledger-root check (the circuit uses the file's
+    // own root), so an empty valid-root set still verifies.
+    let no_roots = HashSet::new();
+    assert!(verify_stateless(&setup.challenges, &proof, &no_roots).unwrap());
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the shared prove/verify preprocessing and introduces an alternate verification path with weaker off-ledger file binding; correctness relies on SNARK + valid-root checks and new equivalence tests.
> 
> **Overview**
> Adds **stateless PoR verification** for hosts that store the file registry on-chain instead of an in-memory `FileLedger`. Public entry points are `verify_stateless` (valid aggregated roots only) and `aggregate_root` / `aggregate_root_from_files` so a contract can recompute the current ledger root in canonical `file_id` order.
> 
> Verification is refactored around a **`LedgerView`** trait (`FileLedger` vs `StatelessLedger`). Shared logic lives in `verify_with`; stateless mode skips per-file `rc` registry checks (callers enforce registration) but still checks multi-file `proof.ledger_root` against the valid-root set and runs the same SNARK path.
> 
> **`Plan::make_plan`** now takes **`AggInputs`**: prove uses `AggInputs::Ledger` (indices + root from the live tree); verify uses `AggInputs::Proof` (SNARK-bound `ledger_root`, `aggregated_tree_depth`, `ledger_indices`). Challenge-derived fields and **`build_z0_primary`** are unified so prover and verifier stay aligned.
> 
> Integration tests assert stateless verify matches ledger verify for single- and multi-file proofs and that missing roots reject multi-file proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114bf3e27e6dafdeea4773499e07c98a485019d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->