### PR TITLE
Crypto/incremental root perf

### DIFF
--- a/crates/kontor-crypto/src/ledger.rs
+++ b/crates/kontor-crypto/src/ledger.rs
@@ -12,7 +12,7 @@
 //! The aggregated tree is built from rc values ordered by `ledger_index`, padded with zeros
 //! for any missing slots. This keeps verifier-side index derivation deterministic.
 
-use crate::merkle::{build_tree_from_leaves, get_padded_proof_for_leaf, MerkleTree, F};
+use crate::merkle::{build_tree_from_leaves, get_padded_proof_for_leaf, hash_node, MerkleTree, F};
 use crate::poseidon::calculate_root_commitment;
 use crate::KontorPoRError;
 use bincode::Options;
@@ -744,6 +744,140 @@ pub fn aggregate_root_from_files(files: &[(F, usize, usize)]) -> Result<[u8; 32]
         })
         .collect();
     aggregate_root(&rc_slots)
+}
+
+/// Zero-subtree roots by height: `Z[0] = 0` (a zero leaf), `Z[h] = node(Z[h-1], Z[h-1])`.
+/// These fill the empty right portion of the aggregated tree, matching the zero-fill +
+/// power-of-two padding that [`aggregate_root`] feeds to `build_tree_from_leaves`.
+fn zero_subtree_roots(max_height: usize) -> Vec<F> {
+    let mut z = Vec::with_capacity(max_height + 1);
+    z.push(F::ZERO);
+    for h in 1..=max_height {
+        let prev = z[h - 1];
+        z.push(hash_node(prev, prev));
+    }
+    z
+}
+
+/// Append-only incremental accumulator for the aggregated ledger root.
+///
+/// Maintains the O(log n) Merkle "mountain peaks" of the contiguous, append-only file
+/// slots, so adding a file is one `O(log n)` fold instead of an `O(n)` tree rebuild.
+/// [`Self::root`] is **byte-identical** to [`aggregate_root`] over the same contiguous
+/// slots `0..count` (see the `frontier_*` equivalence tests), so a contract can persist
+/// just `(count, peaks)` and update the ledger root incrementally each block rather than
+/// recomputing the whole tree.
+///
+/// Only the append-only case is supported — slots assigned `0, 1, 2, …` with no gaps.
+/// Interior removal / zero-fill is intentionally out of scope (it would invalidate the
+/// right-edge peaks); a removal workload would need a full rebuild or a richer structure.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LedgerFrontier {
+    count: u64,
+    /// Perfect-subtree roots, lowest height first — exactly one per set bit of `count`.
+    peaks: Vec<F>,
+}
+
+impl LedgerFrontier {
+    /// An empty frontier (no files), whose [`Self::root`] matches `aggregate_root(&[])`.
+    pub fn new() -> Self {
+        Self {
+            count: 0,
+            peaks: Vec::new(),
+        }
+    }
+
+    /// Reconstruct from persisted state (e.g. a contract reading its own storage).
+    /// Errors unless `peaks.len()` equals the number of set bits in `count`, the
+    /// structural invariant of the mountain-peak representation.
+    pub fn from_parts(count: u64, peaks: Vec<F>) -> Result<Self, KontorPoRError> {
+        if peaks.len() != count.count_ones() as usize {
+            return Err(KontorPoRError::InvalidInput(format!(
+                "LedgerFrontier: got {} peaks for count {} (expected {} set bits)",
+                peaks.len(),
+                count,
+                count.count_ones()
+            )));
+        }
+        Ok(Self { count, peaks })
+    }
+
+    /// Number of appended files (== next slot to be assigned).
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Perfect-subtree peaks, lowest height first — persist these alongside `count`.
+    pub fn peaks(&self) -> &[F] {
+        &self.peaks
+    }
+
+    /// Append a file by its precomputed root-commitment `rc` at the next slot. O(log n).
+    pub fn append_rc(&mut self, rc: F) {
+        // Binary-increment carry: the trailing run of set bits in `count` are the low
+        // peaks that merge with the new leaf. Each existing peak is the LEFT sibling and
+        // the carry the RIGHT — matching `build_tree_from_leaves`'s low-index-left order.
+        let mut carry = rc;
+        let mut h = 0;
+        while (self.count >> h) & 1 == 1 {
+            let left = self.peaks.remove(0);
+            carry = hash_node(left, carry);
+            h += 1;
+        }
+        self.peaks.insert(0, carry);
+        self.count += 1;
+    }
+
+    /// Append a file by its `(root, depth)`, computing `rc` as [`aggregate_root_from_files`]
+    /// does, then folding it in via [`Self::append_rc`].
+    pub fn append(&mut self, root: F, depth: usize) {
+        self.append_rc(calculate_root_commitment(root, F::from(depth as u64)));
+    }
+
+    /// Current aggregated ledger root — byte-identical to [`aggregate_root`] over slots
+    /// `0..count`. Returned as the 32-byte little-endian field repr (matching
+    /// [`FileLedger::historical_roots`]).
+    pub fn root(&self) -> [u8; 32] {
+        use ff::PrimeField;
+
+        if self.count == 0 {
+            // Empty ledger: a single zero leaf (mirrors `aggregate_root`/`rebuild_tree`).
+            return F::ZERO.to_repr().into();
+        }
+
+        // Root height D = ceil(log2(count)) = bit-length(count - 1); D = 0 for count == 1.
+        let d = (u64::BITS - (self.count - 1).leading_zeros()) as usize;
+        let z = zero_subtree_roots(d);
+
+        // Fold peaks low-to-high. `acc` is the root of the accumulated right-hand region
+        // at height `acc_h`; lift it with zero-subtrees to the current height before
+        // combining the next peak (a fully-filled subtree to its left).
+        let mut acc: Option<F> = None;
+        let mut acc_h = 0usize;
+        let mut peaks = self.peaks.iter();
+        for h in 0..=d {
+            if let Some(a) = acc.as_mut() {
+                while acc_h < h {
+                    *a = hash_node(*a, z[acc_h]);
+                    acc_h += 1;
+                }
+            }
+            if (self.count >> h) & 1 == 1 {
+                let p = *peaks.next().expect("peak count matches set bits of count");
+                match acc {
+                    None => {
+                        acc = Some(p);
+                        acc_h = h;
+                    }
+                    Some(a) => {
+                        acc = Some(hash_node(p, a));
+                        acc_h = h + 1;
+                    }
+                }
+            }
+        }
+        acc.expect("count >= 1 yields a root").to_repr().into()
+    }
 }
 
 #[cfg(test)]

--- a/crates/kontor-crypto/src/lib.rs
+++ b/crates/kontor-crypto/src/lib.rs
@@ -103,6 +103,7 @@ pub use circuit::{CircuitWitness, FileProofWitness, PorCircuit};
 pub use error::{KontorPoRError, Result};
 pub use ledger::{
     aggregate_root, aggregate_root_from_files, FileDescriptor, FileLedger, HistoricalRootPolicy,
+    LedgerFrontier,
 };
 pub use merkle::{
     build_tree, build_tree_from_leaves, get_leaf_hash, get_padded_proof_for_leaf, hash_leaf_data,

--- a/crates/kontor-crypto/tests/ledger_frontier.rs
+++ b/crates/kontor-crypto/tests/ledger_frontier.rs
@@ -1,0 +1,86 @@
+//! Equivalence tests for the incremental [`LedgerFrontier`] against the from-scratch
+//! [`aggregate_root_from_files`]. The frontier is only useful if its root is
+//! byte-identical to a full rebuild over the same contiguous, append-only slots — these
+//! tests pin that across every count up to a few power-of-two boundaries (where the
+//! aggregated tree depth grows), plus mixed depths and persisted-state round-trips.
+
+use kontor_crypto::{aggregate_root_from_files, FieldElement, LedgerFrontier};
+
+/// A distinct, deterministic file root for index `i`.
+fn root_for(i: u64) -> FieldElement {
+    FieldElement::from(1_000_003u64 + i)
+}
+
+/// Mixed leaf depths so the test exercises non-trivial `rc = commit(root, depth)` inputs,
+/// not just a constant depth.
+fn depth_for(i: u64) -> usize {
+    (i % 7) as usize
+}
+
+#[test]
+fn frontier_matches_aggregate_root_across_counts() {
+    // Empty ledger first: frontier root must equal the from-scratch empty root.
+    let frontier = LedgerFrontier::new();
+    assert_eq!(
+        frontier.root(),
+        aggregate_root_from_files(&[]).expect("empty aggregate_root"),
+        "empty-ledger root mismatch"
+    );
+
+    // Walk counts 1..=300, which crosses the depth-growth boundaries at 2, 4, 8, …, 256.
+    let mut frontier = LedgerFrontier::new();
+    let mut files: Vec<(FieldElement, usize, usize)> = Vec::new();
+    for i in 0u64..300 {
+        let (root, depth) = (root_for(i), depth_for(i));
+        frontier.append(root, depth);
+        files.push((root, depth, i as usize));
+
+        let expected = aggregate_root_from_files(&files).expect("aggregate_root_from_files");
+        assert_eq!(
+            frontier.root(),
+            expected,
+            "frontier root diverged from aggregate_root at count {}",
+            i + 1
+        );
+        assert_eq!(frontier.count(), i + 1);
+        // Structural invariant: one peak per set bit of the count.
+        assert_eq!(frontier.peaks().len(), (i + 1).count_ones() as usize);
+    }
+}
+
+#[test]
+fn frontier_from_parts_roundtrips_and_validates() {
+    let mut frontier = LedgerFrontier::new();
+    for i in 0u64..37 {
+        frontier.append(root_for(i), depth_for(i));
+    }
+
+    // Persist → reconstruct → identical state and root.
+    let rebuilt = LedgerFrontier::from_parts(frontier.count(), frontier.peaks().to_vec())
+        .expect("valid parts reconstruct");
+    assert_eq!(rebuilt, frontier);
+    assert_eq!(rebuilt.root(), frontier.root());
+
+    // A peak count that doesn't match the set bits of `count` is rejected.
+    assert!(LedgerFrontier::from_parts(0b101, vec![root_for(0)]).is_err());
+    assert!(LedgerFrontier::from_parts(0, vec![root_for(0)]).is_err());
+}
+
+#[test]
+fn frontier_append_is_incremental_not_order_dependent_on_slots() {
+    // Appending in slot order must equal a fresh full rebuild that lists files in any
+    // order (aggregate_root sorts by slot internally), confirming the frontier's
+    // low-index-left fold matches the canonical slot layout.
+    let mut frontier = LedgerFrontier::new();
+    let mut files: Vec<(FieldElement, usize, usize)> = Vec::new();
+    for i in 0u64..16 {
+        frontier.append(root_for(i), depth_for(i));
+        files.push((root_for(i), depth_for(i), i as usize));
+    }
+    let mut shuffled = files.clone();
+    shuffled.reverse();
+    assert_eq!(
+        frontier.root(),
+        aggregate_root_from_files(&shuffled).expect("aggregate over reversed input")
+    );
+}

--- a/tools/picus/components/fixtures/comp-agg-merkle-multi.json
+++ b/tools/picus/components/fixtures/comp-agg-merkle-multi.json
@@ -32,5 +32,5 @@
     "aggregation_merkle",
     "multi"
   ],
-  "expected_num_constraints": 8686
+  "expected_num_constraints": 8854
 }

--- a/tools/picus/components/fixtures/comp-agg-merkle-single.json
+++ b/tools/picus/components/fixtures/comp-agg-merkle-single.json
@@ -24,5 +24,5 @@
     "aggregation_merkle",
     "single"
   ],
-  "expected_num_constraints": 1215
+  "expected_num_constraints": 1257
 }

--- a/tools/picus/components/fixtures/comp-file-merkle-multi.json
+++ b/tools/picus/components/fixtures/comp-file-merkle-multi.json
@@ -32,5 +32,5 @@
     "file_merkle",
     "multi"
   ],
-  "expected_num_constraints": 20218
+  "expected_num_constraints": 20386
 }

--- a/tools/picus/components/fixtures/comp-file-merkle-single.json
+++ b/tools/picus/components/fixtures/comp-file-merkle-single.json
@@ -24,5 +24,5 @@
     "file_merkle",
     "single"
   ],
-  "expected_num_constraints": 4580
+  "expected_num_constraints": 4622
 }

--- a/tools/picus/fixtures/multi-file-minimal.json
+++ b/tools/picus/fixtures/multi-file-minimal.json
@@ -39,5 +39,5 @@
     "smoke",
     "multi"
   ],
-  "expected_num_constraints": 14549
+  "expected_num_constraints": 14717
 }

--- a/tools/picus/fixtures/multi-file-mixed-depth.json
+++ b/tools/picus/fixtures/multi-file-mixed-depth.json
@@ -39,5 +39,5 @@
     "multi",
     "mixed-depth"
   ],
-  "expected_num_constraints": 16477
+  "expected_num_constraints": 16645
 }

--- a/tools/picus/fixtures/multi-file-padding.json
+++ b/tools/picus/fixtures/multi-file-padding.json
@@ -43,5 +43,5 @@
     "multi",
     "padding"
   ],
-  "expected_num_constraints": 31013
+  "expected_num_constraints": 31349
 }

--- a/tools/picus/fixtures/single-file-depth10.json
+++ b/tools/picus/fixtures/single-file-depth10.json
@@ -35,5 +35,5 @@
     "single",
     "depth"
   ],
-  "expected_num_constraints": 7028
+  "expected_num_constraints": 7070
 }

--- a/tools/picus/fixtures/single-file-minimal.json
+++ b/tools/picus/fixtures/single-file-minimal.json
@@ -35,5 +35,5 @@
     "smoke",
     "single"
   ],
-  "expected_num_constraints": 6064
+  "expected_num_constraints": 6106
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core ledger root semantics via new Merkle folding code; risk is mitigated by extensive equivalence tests against aggregate_root, but any bug would break on-chain/off-chain root agreement.
> 
> **Overview**
> Adds **`LedgerFrontier`**, an append-only accumulator that maintains Merkle “mountain peaks” so each new file folds in with **O(log n)** work instead of rebuilding the full aggregated tree. **`root()`** is documented and tested to match **`aggregate_root` / `aggregate_root_from_files`** for contiguous slots `0..count`, with **`from_parts(count, peaks)`** for persisted on-chain-style state.
> 
> Supporting logic includes **`zero_subtree_roots`** and use of **`hash_node`** when folding peaks and zero-padding the right edge. **`LedgerFrontier`** is re-exported from the crate root. New integration tests in **`ledger_frontier.rs`** cover counts through depth boundaries, **`from_parts`** validation, and slot ordering. Picus JSON fixtures only bump **`expected_num_constraints`** (no circuit logic in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b040fac6038dab6395bb1f2975e340ca9165ad88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->