### PR TITLE
[codex] Harden verifier and tooling security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,25 +42,29 @@ jobs:
       - name: Build workspace
         run: cargo build --workspace
 
-      # 5. Check formatting.
+      # 5. Ensure excluded fuzz crate lockfile stays current.
+      - name: Check fuzz lockfile
+        run: cargo metadata --manifest-path fuzz/Cargo.toml --locked --format-version=1 >/dev/null
+
+      # 6. Check formatting.
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      # 6. Lint with clippy.
+      # 7. Lint with clippy.
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
-      # 7. Run tests (--all-features enables nova_poseidon in core).
+      # 8. Run tests (--all-features enables nova_poseidon in core).
       - name: Run tests
         run: cargo test --all-features --workspace
 
-      # 8. Test core crate without --all-features so the standalone Poseidon
+      # 9. Test core crate without --all-features so the standalone Poseidon
       #    path (used in WASM) is exercised. Feature unification in step 7
       #    enables nova_poseidon, which hides #[cfg(not(feature = "nova_poseidon"))] tests.
       - name: Test core standalone Poseidon (no nova_poseidon)
         run: cargo test -p kontor-crypto-core
 
-      # 9. Run security audit.
+      # 10. Run security audit.
       # The command will fail the workflow if any vulnerabilities are found.
       - name: Install cargo-audit
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,8 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm for Trusted Publisher provenance
-        run: npm install -g npm@latest
+      - name: Show npm version
+        run: npm --version
 
       - name: Verify npm package version matches release tag
         working-directory: packages/kontor-crypto

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Blocking controls include:
 Quick start (Dockerized Picus):
 
 ```bash
+export PICUS_DOCKER_IMAGE='veridise/picus:base@sha256:fc396dbabd92cb0026a52dd3f2f72893374a1fc29367409cb49f251923089162'
+
 # sanity-check Dockerized run-picus
 tools/picus/check-docker.sh
 

--- a/crates/kontor-crypto-core/src/merkle.rs
+++ b/crates/kontor-crypto-core/src/merkle.rs
@@ -32,7 +32,7 @@ pub fn get_leaf_hash(data: &[u8]) -> Result<FieldElement> {
     if data.is_empty() {
         return Ok(FieldElement::ZERO);
     }
-    Ok(bytes31_to_field_le::<FieldElement>(data))
+    bytes31_to_field_le::<FieldElement>(data)
 }
 
 /// Merkle tree with layers from leaves (layer 0) to root.

--- a/crates/kontor-crypto-core/src/poseidon.rs
+++ b/crates/kontor-crypto-core/src/poseidon.rs
@@ -913,14 +913,16 @@ mod tests {
             poseidon_hash2(Fq::from(0u64), Fq::from(0u64)),
             field_from_hex::<Fq>(
                 "bd5d8b55dce90161d02aaeaabc218b79728e051164b79fd65065898c7869ec38"
-            ),
+            )
+            .unwrap(),
             "poseidon_hash2(0,0) must match Nova"
         );
         assert_eq!(
             poseidon_hash_tagged(domain_tags::leaf(), Fq::from(1u64), Fq::from(2u64)),
             field_from_hex::<Fq>(
                 "951402865ad780f82a9399ccb4a223ec32eae8870a24f56adc0683353b92b32e"
-            ),
+            )
+            .unwrap(),
             "poseidon_hash_tagged(leaf,1,2) must match Nova"
         );
     }

--- a/crates/kontor-crypto-core/src/utils.rs
+++ b/crates/kontor-crypto-core/src/utils.rs
@@ -1,19 +1,23 @@
 //! Field conversion utilities for Pallas scalar (31-byte chunks).
 
+use crate::error::{CoreError, Result};
 use ff::PrimeField;
 
 /// Convert up to 31 little-endian bytes into a field element using the
 /// canonical byte representation expected by `ff::PrimeField::from_repr`.
-pub fn bytes31_to_field_le<F: PrimeField>(bytes31: &[u8]) -> F {
-    assert!(
-        bytes31.len() <= 31,
-        "bytes31_to_field_le: input length {} exceeds 31 bytes",
-        bytes31.len()
-    );
+pub fn bytes31_to_field_le<F: PrimeField>(bytes31: &[u8]) -> Result<F> {
+    if bytes31.len() > 31 {
+        return Err(CoreError::InvalidInput(format!(
+            "bytes31_to_field_le: input length {} exceeds 31 bytes",
+            bytes31.len()
+        )));
+    }
     let mut repr = <F as PrimeField>::Repr::default();
     let buf = repr.as_mut();
     buf[..bytes31.len()].copy_from_slice(bytes31);
-    F::from_repr(repr).expect("31-byte chunks should always fit in the field")
+    F::from_repr(repr).into_option().ok_or_else(|| {
+        CoreError::InvalidInput("bytes31_to_field_le: input does not fit in field".to_string())
+    })
 }
 
 /// Convert a field element to its first 31 little-endian bytes.
@@ -47,16 +51,38 @@ pub fn field_to_hex<F: PrimeField>(f: &F) -> String {
 ///
 /// Bytes are interpreted as the canonical `PrimeField::Repr`
 /// (little-endian for Pallas Fq), matching [`field_to_hex`].
-pub fn field_from_hex<F: PrimeField>(hex: &str) -> F {
-    let hex = hex.trim_start_matches("0x");
+pub fn field_from_hex<F: PrimeField>(hex: &str) -> Result<F> {
+    let hex = hex
+        .strip_prefix("0x")
+        .or_else(|| hex.strip_prefix("0X"))
+        .unwrap_or(hex);
+    if hex.len() != 64 {
+        return Err(CoreError::InvalidInput(format!(
+            "field_from_hex: expected 64 hex characters, got {}",
+            hex.len()
+        )));
+    }
+    if !hex.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err(CoreError::InvalidInput(
+            "field_from_hex: input contains non-hex characters".to_string(),
+        ));
+    }
+
     let mut buf = [0u8; 32];
     for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
-        let s = core::str::from_utf8(chunk).expect("hex must be valid UTF-8");
-        buf[i] = u8::from_str_radix(s, 16).expect("hex must contain valid hex digits");
+        let s = core::str::from_utf8(chunk).map_err(|_| {
+            CoreError::InvalidInput("field_from_hex: hex must be valid UTF-8".to_string())
+        })?;
+        buf[i] = u8::from_str_radix(s, 16)
+            .map_err(|_| CoreError::InvalidInput("field_from_hex: invalid hex byte".to_string()))?;
     }
     let mut repr = <F as PrimeField>::Repr::default();
     repr.as_mut().copy_from_slice(&buf);
-    F::from_repr(repr).expect("hex value must fit in the field")
+    F::from_repr(repr).into_option().ok_or_else(|| {
+        CoreError::InvalidInput(
+            "field_from_hex: hex value is not a canonical field element".to_string(),
+        )
+    })
 }
 
 #[cfg(test)]
@@ -80,7 +106,7 @@ mod tests {
         for i in 0u64..100 {
             let fe = Fq::from(i.wrapping_mul(2654435761));
             let hex = field_to_hex(&fe);
-            let recovered: Fq = field_from_hex(&hex);
+            let recovered: Fq = field_from_hex(&hex).unwrap();
             assert_eq!(fe, recovered, "round-trip failed at i={i}");
         }
     }
@@ -90,7 +116,7 @@ mod tests {
         // hex string round-trip
         let fe = Fq::from(0x1234_5678_9abc_def0u64);
         let hex = field_to_hex(&fe);
-        let again = field_to_hex(&field_from_hex::<Fq>(&hex));
+        let again = field_to_hex(&field_from_hex::<Fq>(&hex).unwrap());
         assert_eq!(hex, again);
     }
 
@@ -99,6 +125,20 @@ mod tests {
         let fe = Fq::from(42u64);
         let hex = field_to_hex(&fe);
         let prefixed = format!("0x{hex}");
-        assert_eq!(field_from_hex::<Fq>(&prefixed), fe);
+        assert_eq!(field_from_hex::<Fq>(&prefixed).unwrap(), fe);
+    }
+
+    #[test]
+    fn field_from_hex_rejects_malformed_input() {
+        assert!(field_from_hex::<Fq>("").is_err());
+        assert!(field_from_hex::<Fq>("abc").is_err());
+        assert!(field_from_hex::<Fq>(&"00".repeat(33)).is_err());
+        assert!(field_from_hex::<Fq>(&format!("{}zz", "00".repeat(31))).is_err());
+    }
+
+    #[test]
+    fn bytes31_to_field_le_rejects_overlong_input() {
+        assert!(bytes31_to_field_le::<Fq>(&[0u8; 31]).is_ok());
+        assert!(bytes31_to_field_le::<Fq>(&[0u8; 32]).is_err());
     }
 }

--- a/crates/kontor-crypto-wasm/README.md
+++ b/crates/kontor-crypto-wasm/README.md
@@ -119,7 +119,7 @@ Throws if input is empty or encoding fails.
   node examples/node_prepare_file.mjs
   ```
   Calls `prepareFile` with fixed input and asserts metadata and `preparedFile` shape and consistency.
-- **Browser example:** from `crates/kontor-crypto-wasm/`, run `wasm-pack build --target web`, then serve the crate directory (`npx serve .`). Open `http://localhost:3000/examples/browser_prepare_file.html` in a browser. The example imports `../pkg/kontor_crypto_wasm.js`, so the `pkg/` directory must be at the crate root. Verifies same metadata/preparedFile consistency from the browser.
+- **Browser example:** from `crates/kontor-crypto-wasm/`, run `wasm-pack build --target web`, then serve the crate directory with `python3 -m http.server 4000 --bind 127.0.0.1`. Open `http://127.0.0.1:4000/examples/browser_prepare_file.html` in a browser. The example imports `../pkg/kontor_crypto_wasm.js`, so the `pkg/` directory must be at the crate root. Verifies same metadata/preparedFile consistency from the browser.
 
 ## Package (npm)
 

--- a/crates/kontor-crypto/src/api/mod.rs
+++ b/crates/kontor-crypto/src/api/mod.rs
@@ -81,7 +81,7 @@ pub use types::{
 // Stateless verification: verify a constant-size proof from bare registry data (the
 // valid-root set + a `file_id -> (slot, rc)` snapshot) instead of a live `FileLedger`.
 // For hosts that keep the file registry in contract storage.
-pub use verify::{verify_stateless, LedgerView, StatelessLedger};
+pub use verify::{verify_stateless, LedgerView, RootDepthRequirement, StatelessLedger};
 
 // Internal modules can access these for implementation
 // Export for testing - these are implementation details

--- a/crates/kontor-crypto/src/api/verify.rs
+++ b/crates/kontor-crypto/src/api/verify.rs
@@ -12,6 +12,31 @@ use ff::PrimeField;
 use std::collections::{BTreeMap, HashSet};
 use tracing::{debug, info_span};
 
+/// How tightly a ledger view can bind an accepted root to aggregation depth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootDepthRequirement {
+    /// The root is accepted only at this exact aggregation depth.
+    Exact(usize),
+    /// The root is accepted for depths up to and including this bound.
+    Max(usize),
+}
+
+impl RootDepthRequirement {
+    fn accepts(self, depth: usize) -> bool {
+        match self {
+            RootDepthRequirement::Exact(expected) => depth == expected,
+            RootDepthRequirement::Max(max) => depth <= max,
+        }
+    }
+
+    fn describe(self) -> String {
+        match self {
+            RootDepthRequirement::Exact(expected) => format!("expected exact depth {expected}"),
+            RootDepthRequirement::Max(max) => format!("maximum accepted depth {max}"),
+        }
+    }
+}
+
 /// What proof verification needs from "the ledger": resolve each challenged file's
 /// stable, append-only slot (and its registered root-commitment), and decide whether
 /// a `ledger_root` is accepted.
@@ -29,6 +54,9 @@ pub trait LedgerView {
 
     /// Whether `root` is an accepted aggregated ledger root (current or historical).
     fn is_valid_root(&self, root: FieldElement) -> bool;
+
+    /// Depth policy for an accepted aggregated ledger root.
+    fn root_depth_requirement(&self, root: FieldElement) -> Option<RootDepthRequirement>;
 }
 
 impl LedgerView for FileLedger {
@@ -38,6 +66,10 @@ impl LedgerView for FileLedger {
 
     fn is_valid_root(&self, root: FieldElement) -> bool {
         FileLedger::is_valid_root(self, root)
+    }
+
+    fn root_depth_requirement(&self, root: FieldElement) -> Option<RootDepthRequirement> {
+        FileLedger::accepted_root_depth(self, root).map(RootDepthRequirement::Exact)
     }
 }
 
@@ -53,11 +85,12 @@ impl LedgerView for FileLedger {
 /// `FileLedger::historical_roots`). Compute them from the on-chain files with
 /// [`crate::ledger::aggregate_root`] / [`crate::ledger::aggregate_root_from_files`].
 ///
-/// Note: a proof's `aggregated_tree_depth` is bound to its `ledger_root` only
-/// cryptographically (via Poseidon root equality), not by a structural check here —
-/// the same trust model as the live [`FileLedger`]. Callers must therefore only admit
-/// roots into `valid_roots` that they actually produced from their own files (e.g. via
-/// [`crate::ledger::aggregate_root`]); never roots of unknown provenance/depth.
+/// Because this stateless view stores roots without per-root depths, verification bounds
+/// `aggregated_tree_depth` by the current registry's implied aggregation depth before
+/// parameter loading. Callers that retain historical roots should prefer an external
+/// `(root, depth)` policy when they can enforce one at the host/contract boundary.
+/// Callers must only admit roots into `valid_roots` that they produced from their own
+/// files (e.g. via [`crate::ledger::aggregate_root`]); never roots of unknown provenance.
 pub struct StatelessLedger<'a> {
     /// Accepted aggregated roots ({current} ∪ historical).
     pub valid_roots: &'a HashSet<[u8; 32]>,
@@ -73,6 +106,18 @@ impl LedgerView for StatelessLedger<'_> {
     fn is_valid_root(&self, root: FieldElement) -> bool {
         let repr: [u8; 32] = root.to_repr().into();
         self.valid_roots.contains(&repr)
+    }
+
+    fn root_depth_requirement(&self, root: FieldElement) -> Option<RootDepthRequirement> {
+        if !self.is_valid_root(root) {
+            return None;
+        }
+        let max_index = self.files.values().map(|(idx, _rc)| *idx).max()?;
+        let leaf_count = max_index.checked_add(1)?;
+        let padded_leaf_count = leaf_count.next_power_of_two();
+        Some(RootDepthRequirement::Max(
+            padded_leaf_count.trailing_zeros() as usize,
+        ))
     }
 }
 
@@ -133,6 +178,13 @@ fn verify_with(challenges: &[Challenge], proof: &Proof, view: &dyn LedgerView) -
         return Err(KontorPoRError::InvalidInput(
             "Must provide at least one challenge".to_string(),
         ));
+    }
+
+    if challenges.len() > config::PRACTICAL_MAX_FILES {
+        return Err(KontorPoRError::TooManyFiles {
+            got: challenges.len(),
+            max: config::PRACTICAL_MAX_FILES,
+        });
     }
 
     // Validate challenge structure/metadata invariants before any cryptographic checks.
@@ -206,24 +258,33 @@ fn verify_with(challenges: &[Challenge], proof: &Proof, view: &dyn LedgerView) -
         }
     }
 
-    // --- Historical root validation (multi-file only) ---
+    // --- Historical root/depth validation (multi-file only) ---
     //
     // For multi-file proofs, `proof.ledger_root` must be either the current root or a retained
-    // historical root. For single-file proofs, the circuit uses the file's root directly.
-    if is_multi_file && !view.is_valid_root(proof.ledger_root) {
-        debug!(
-            "Proof ledger_root {:?} is not in the set of valid roots",
-            proof.ledger_root
-        );
-        return Err(KontorPoRError::InvalidLedgerRoot {
-            proof_root: format!("{:?}", proof.ledger_root),
-            reason: "Proof's ledger_root is not in the set of valid historical roots".to_string(),
-        });
-    }
+    // historical root at an accepted depth. For single-file proofs, the circuit uses the file's
+    // root directly.
     if is_multi_file {
+        let depth_requirement =
+            view.root_depth_requirement(proof.ledger_root)
+                .ok_or_else(|| KontorPoRError::InvalidLedgerRoot {
+                    proof_root: format!("{:?}", proof.ledger_root),
+                    reason: "Proof's ledger_root is not accepted with a known aggregation depth"
+                        .to_string(),
+                })?;
+        if !depth_requirement.accepts(proof.aggregated_tree_depth) {
+            return Err(KontorPoRError::InvalidLedgerRoot {
+                proof_root: format!("{:?}", proof.ledger_root),
+                reason: format!(
+                    "Proof aggregated_tree_depth {} does not satisfy {}",
+                    proof.aggregated_tree_depth,
+                    depth_requirement.describe()
+                ),
+            });
+        }
+
         debug!(
-            "Proof ledger_root {:?} validated as historical root",
-            proof.ledger_root
+            "Proof ledger_root {:?} validated with depth requirement {:?}",
+            proof.ledger_root, depth_requirement
         );
     }
 

--- a/crates/kontor-crypto/src/config.rs
+++ b/crates/kontor-crypto/src/config.rs
@@ -285,8 +285,14 @@ pub const MAX_PROOF_SIZE_BYTES: usize = 50 * 1024 * 1024;
 /// Older roots are pruned when this cap is exceeded.
 pub const DEFAULT_MAX_HISTORICAL_ROOTS: usize = 4096;
 
-/// Current ledger format version
-pub const LEDGER_FORMAT_VERSION: u16 = 2;
+/// Current ledger format version.
+///
+/// Version 3 persists historical root depths so verifiers can bind accepted
+/// ledger roots to bounded aggregation shapes before loading parameters.
+pub const LEDGER_FORMAT_VERSION: u16 = 3;
+
+/// Previous ledger format accepted for backwards-compatible loading.
+pub const LEGACY_LEDGER_FORMAT_VERSION_V2: u16 = 2;
 
 // --- Test-related Constants ---
 

--- a/crates/kontor-crypto/src/ledger.rs
+++ b/crates/kontor-crypto/src/ledger.rs
@@ -107,7 +107,48 @@ struct LedgerData {
     #[serde(default)]
     historical_roots: Vec<[u8; 32]>,
     #[serde(default)]
+    historical_root_depths: BTreeMap<[u8; 32], usize>,
+    #[serde(default)]
     historical_root_policy: HistoricalRootPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LegacyLedgerDataV2 {
+    version: u16,
+    files: BTreeMap<String, IndexedFileLedgerEntry>,
+    root: F,
+    #[serde(default)]
+    historical_roots: Vec<[u8; 32]>,
+    #[serde(default)]
+    historical_root_policy: HistoricalRootPolicy,
+}
+
+fn load_legacy_ledger_data_v2(encoded: &[u8]) -> Result<LedgerData, KontorPoRError> {
+    let options = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_little_endian()
+        .with_limit(crate::config::MAX_LEDGER_SIZE_BYTES as u64)
+        .reject_trailing_bytes();
+    let data: LegacyLedgerDataV2 = options.deserialize(encoded).map_err(|e| {
+        KontorPoRError::Serialization(format!("Failed to deserialize legacy v2 ledger: {}", e))
+    })?;
+
+    if data.version != crate::config::LEGACY_LEDGER_FORMAT_VERSION_V2 {
+        return Err(KontorPoRError::InvalidInput(format!(
+            "Ledger format version {} is not compatible with current version {}",
+            data.version,
+            crate::config::LEDGER_FORMAT_VERSION
+        )));
+    }
+
+    Ok(LedgerData {
+        version: crate::config::LEDGER_FORMAT_VERSION,
+        files: data.files,
+        root: data.root,
+        historical_roots: data.historical_roots,
+        historical_root_depths: BTreeMap::new(),
+        historical_root_policy: data.historical_root_policy,
+    })
 }
 
 /// The `FileLedger` manages the aggregated Merkle tree of all file roots.
@@ -141,6 +182,14 @@ pub struct FileLedger {
     /// Use [`Self::set_historical_roots`] to replace this list.
     #[serde(default)]
     pub historical_roots: Vec<[u8; 32]>,
+    /// Known depth for each accepted historical root.
+    ///
+    /// This is intentionally private: callers may still inspect and replace the
+    /// root list, but verification only treats a historical root as shape-bound
+    /// when its depth was recorded by the ledger or supplied through
+    /// [`Self::set_historical_roots_with_depths`].
+    #[serde(default)]
+    historical_root_depths: BTreeMap<[u8; 32], usize>,
     /// Historical-root retention policy.
     #[serde(default)]
     pub historical_root_policy: HistoricalRootPolicy,
@@ -160,6 +209,7 @@ impl Default for FileLedger {
                 layers: vec![vec![]],
             },
             historical_roots: Vec::new(),
+            historical_root_depths: BTreeMap::new(),
             historical_root_policy: HistoricalRootPolicy::default(),
             index_to_file_id: HashMap::new(),
             next_ledger_index: 0,
@@ -188,6 +238,8 @@ impl FileLedger {
         use ff::PrimeField;
         let root = self.tree.root();
         let repr: [u8; 32] = root.to_repr().into();
+        let depth = self.depth();
+        self.historical_root_depths.insert(repr, depth);
         self.historical_roots.push(repr);
         self.prune_historical_roots();
     }
@@ -205,11 +257,40 @@ impl FileLedger {
         self.historical_roots.iter().any(|r| r == &repr)
     }
 
+    /// Returns the exact accepted aggregation depth for `root`, when known.
+    ///
+    /// Current roots are always bound to the current ledger depth. Historical
+    /// roots are accepted here only when their depth was recorded alongside the
+    /// root; root-only historical entries still satisfy [`Self::is_valid_root`]
+    /// for compatibility, but cannot pass multi-file proof verification.
+    pub fn accepted_root_depth(&self, root: F) -> Option<usize> {
+        use ff::PrimeField;
+        if root == self.tree.root() {
+            return Some(self.depth());
+        }
+        let repr: [u8; 32] = root.to_repr().into();
+        if self.historical_roots.iter().any(|r| r == &repr) {
+            return self.historical_root_depths.get(&repr).copied();
+        }
+        None
+    }
+
     /// Sets the historical roots to the given list.
     ///
     /// This replaces any existing historical roots with the provided values.
     pub fn set_historical_roots(&mut self, roots: Vec<[u8; 32]>) {
         self.historical_roots = roots;
+        self.prune_historical_roots();
+    }
+
+    /// Replaces historical roots with explicit root-depth pairs.
+    ///
+    /// Use this when reconstructing a verifier ledger from external storage:
+    /// multi-file proof verification needs both the accepted root and the
+    /// aggregation depth that produced it.
+    pub fn set_historical_roots_with_depths(&mut self, roots: Vec<([u8; 32], usize)>) {
+        self.historical_roots = roots.iter().map(|(root, _depth)| *root).collect();
+        self.historical_root_depths = roots.into_iter().collect();
         self.prune_historical_roots();
     }
 
@@ -527,6 +608,41 @@ impl FileLedger {
         Ok(())
     }
 
+    fn rebuild_missing_historical_root_depths(&mut self) -> Result<(), KontorPoRError> {
+        let wanted: HashSet<[u8; 32]> = self.historical_roots.iter().copied().collect();
+        if wanted.is_empty()
+            || wanted
+                .iter()
+                .all(|root| self.historical_root_depths.contains_key(root))
+        {
+            self.retain_historical_root_depths();
+            return Ok(());
+        }
+
+        let mut by_index: Vec<(usize, F)> = self
+            .files
+            .values()
+            .map(|entry| (entry.ledger_index, entry.entry.rc))
+            .collect();
+        by_index.sort_by_key(|(idx, _rc)| *idx);
+
+        let mut prefix = Vec::new();
+        for (expected_idx, (idx, rc)) in by_index.iter().copied().enumerate() {
+            if idx != expected_idx {
+                break;
+            }
+            prefix.push((rc, idx));
+            let root = aggregate_root(&prefix)?;
+            if wanted.contains(&root) {
+                let depth = prefix.len().next_power_of_two().trailing_zeros() as usize;
+                self.historical_root_depths.insert(root, depth);
+            }
+        }
+
+        self.retain_historical_root_depths();
+        Ok(())
+    }
+
     /// Returns the next append-only ledger index that will be assigned.
     pub fn next_ledger_index(&self) -> usize {
         self.next_ledger_index
@@ -548,6 +664,7 @@ impl FileLedger {
             files: self.files.clone(),
             root: self.tree.root(),
             historical_roots: self.historical_roots.clone(),
+            historical_root_depths: self.historical_root_depths.clone(),
             historical_root_policy: self.historical_root_policy,
         };
 
@@ -604,28 +721,36 @@ impl FileLedger {
             .with_little_endian()
             .with_limit(crate::config::MAX_LEDGER_SIZE_BYTES as u64)
             .reject_trailing_bytes();
-        let data: LedgerData = options.deserialize(&encoded).map_err(|e| {
-            KontorPoRError::Serialization(format!("Failed to deserialize ledger: {}", e))
-        })?;
-
-        if data.version != crate::config::LEDGER_FORMAT_VERSION {
-            return Err(KontorPoRError::InvalidInput(format!(
-                "Ledger format version {} is not compatible with current version {}",
-                data.version,
-                crate::config::LEDGER_FORMAT_VERSION
-            )));
-        }
+        let data = match options.deserialize::<LedgerData>(&encoded) {
+            Ok(data) if data.version == crate::config::LEDGER_FORMAT_VERSION => data,
+            Ok(data) => load_legacy_ledger_data_v2(&encoded).map_err(|legacy_err| {
+                KontorPoRError::InvalidInput(format!(
+                    "Ledger format version {} is not compatible with current version {}; legacy load failed: {}",
+                    data.version,
+                    crate::config::LEDGER_FORMAT_VERSION,
+                    legacy_err
+                ))
+            })?,
+            Err(current_err) => load_legacy_ledger_data_v2(&encoded).map_err(|legacy_err| {
+                KontorPoRError::Serialization(format!(
+                    "Failed to deserialize ledger: {}; legacy v2 load failed: {}",
+                    current_err, legacy_err
+                ))
+            })?,
+        };
 
         let mut ledger = FileLedger {
             files: data.files,
             tree: MerkleTree::default(),
             historical_roots: data.historical_roots,
+            historical_root_depths: data.historical_root_depths,
             historical_root_policy: data.historical_root_policy,
             index_to_file_id: HashMap::new(),
             next_ledger_index: 0,
         };
         ledger.rebuild_runtime_index_cache()?;
         ledger.rebuild_tree()?;
+        ledger.rebuild_missing_historical_root_depths()?;
         ledger.prune_historical_roots();
 
         if ledger.tree.root() != data.root {
@@ -672,6 +797,13 @@ impl FileLedger {
                 }
             }
         }
+        self.retain_historical_root_depths();
+    }
+
+    fn retain_historical_root_depths(&mut self) {
+        let retained: HashSet<[u8; 32]> = self.historical_roots.iter().copied().collect();
+        self.historical_root_depths
+            .retain(|root, _depth| retained.contains(root));
     }
 }
 
@@ -896,6 +1028,7 @@ mod security_tests {
             files: BTreeMap::new(),
             root,
             historical_roots: vec![],
+            historical_root_depths: BTreeMap::new(),
             historical_root_policy: HistoricalRootPolicy::Unlimited,
         };
 

--- a/crates/kontor-crypto/tests/poseidon_regression.rs
+++ b/crates/kontor-crypto/tests/poseidon_regression.rs
@@ -17,7 +17,8 @@ fn poseidon_hash2_zero_zero() {
         poseidon_hash2(FieldElement::from(0u64), FieldElement::from(0u64)),
         field_from_hex::<FieldElement>(
             "bd5d8b55dce90161d02aaeaabc218b79728e051164b79fd65065898c7869ec38"
-        ),
+        )
+        .unwrap(),
         "poseidon_hash2(0,0)"
     );
 }
@@ -28,7 +29,8 @@ fn poseidon_hash2_one_two() {
         poseidon_hash2(FieldElement::from(1u64), FieldElement::from(2u64)),
         field_from_hex::<FieldElement>(
             "613f28921329135c38b5465cd51caeca477e3bc5cd1cb9e659461732444c1f04"
-        ),
+        )
+        .unwrap(),
         "poseidon_hash2(1,2)"
     );
 }
@@ -43,7 +45,8 @@ fn poseidon_hash_tagged_leaf_1_2() {
         ),
         field_from_hex::<FieldElement>(
             "951402865ad780f82a9399ccb4a223ec32eae8870a24f56adc0683353b92b32e"
-        ),
+        )
+        .unwrap(),
         "poseidon_hash_tagged(leaf,1,2)"
     );
 }
@@ -58,7 +61,8 @@ fn poseidon_hash_tagged_node_42_123() {
         ),
         field_from_hex::<FieldElement>(
             "2a77f2bbd4f43f29b224e5428492914ce9f27829cd9f4c13218a36b790b29237"
-        ),
+        )
+        .unwrap(),
         "poseidon_hash_tagged(node,42,123)"
     );
 }

--- a/crates/kontor-crypto/tests/public_leaf_exposure.rs
+++ b/crates/kontor-crypto/tests/public_leaf_exposure.rs
@@ -133,7 +133,7 @@ fn test_bytes31_field_helpers_round_trip_and_known_values() {
     ];
 
     for p in patterns {
-        let fe = bytes31_to_field_le::<FieldElement>(&p);
+        let fe = bytes31_to_field_le::<FieldElement>(&p).unwrap();
         let back = field_to_bytes31_le(&fe);
         assert_eq!(back[..p.len()], p[..]);
         assert!(back[p.len()..].iter().all(|&b| b == 0));
@@ -141,7 +141,7 @@ fn test_bytes31_field_helpers_round_trip_and_known_values() {
 
     // Known small numbers
     for i in 0u8..=16 {
-        let fe = bytes31_to_field_le::<FieldElement>(&[i]);
+        let fe = bytes31_to_field_le::<FieldElement>(&[i]).unwrap();
         assert_eq!(fe, FieldElement::from(i as u64));
     }
 }

--- a/crates/kontor-crypto/tests/stateless_verify.rs
+++ b/crates/kontor-crypto/tests/stateless_verify.rs
@@ -81,6 +81,13 @@ fn stateless_matches_ledger_multi_file() {
         verify_stateless(&setup.challenges, &proof, &empty_view),
         Err(KontorPoRError::InvalidLedgerRoot { .. })
     ));
+
+    let mut inflated_depth_proof = proof;
+    inflated_depth_proof.aggregated_tree_depth = usize::BITS as usize - 1;
+    assert!(matches!(
+        verify_stateless(&setup.challenges, &inflated_depth_proof, &view),
+        Err(KontorPoRError::InvalidLedgerRoot { .. })
+    ));
 }
 
 #[test]

--- a/crates/kontor-crypto/tests/verifier_edge_cases.rs
+++ b/crates/kontor-crypto/tests/verifier_edge_cases.rs
@@ -1,6 +1,7 @@
 //! Tests for malicious or non-standard verifier inputs and edge cases
 
 use kontor_crypto::api::{self, Challenge, FieldElement};
+use kontor_crypto::config;
 use kontor_crypto::KontorPoRError;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -49,6 +50,67 @@ fn test_verifier_rejects_out_of_range_ledger_index() {
     assert!(
         matches!(res, Err(KontorPoRError::InvalidInput(_))),
         "Expected InvalidInput for out-of-range derived ledger index, got: {res:?}"
+    );
+}
+
+#[test]
+fn test_verifier_rejects_too_many_files_before_planning() {
+    let data = vec![9u8; 100];
+    let (prepared, metadata) =
+        api::prepare_file(&data, "too_many.dat", &nonce("too_many")).unwrap();
+
+    let mut ledger = kontor_crypto::FileLedger::new();
+    ledger.add_file(&metadata).unwrap();
+
+    let challenge = Challenge::new_test(metadata.clone(), 1000, 1, FieldElement::from(9u64));
+    let system = kontor_crypto::api::PorSystem::new(&ledger);
+    let proof = system
+        .prove(vec![&prepared], std::slice::from_ref(&challenge))
+        .expect("Should generate a valid single-file proof");
+
+    let oversized = vec![challenge; config::PRACTICAL_MAX_FILES + 1];
+    let res = system.verify(&proof, &oversized);
+    assert!(
+        matches!(
+            res,
+            Err(KontorPoRError::TooManyFiles {
+                got,
+                max
+            }) if got == config::PRACTICAL_MAX_FILES + 1
+                && max == config::PRACTICAL_MAX_FILES
+        ),
+        "Expected TooManyFiles before duplicate detection or planning, got: {res:?}"
+    );
+}
+
+#[test]
+fn test_verifier_rejects_inflated_aggregation_depth_before_params() {
+    let data_a = vec![5u8; 100];
+    let data_b = vec![6u8; 100];
+    let (prepared_a, meta_a) =
+        api::prepare_file(&data_a, "inflated_a.dat", &nonce("inflated_a")).unwrap();
+    let (prepared_b, meta_b) =
+        api::prepare_file(&data_b, "inflated_b.dat", &nonce("inflated_b")).unwrap();
+
+    let mut ledger = kontor_crypto::FileLedger::new();
+    ledger.add_file(&meta_a).unwrap();
+    ledger.add_file(&meta_b).unwrap();
+
+    let challenges = vec![
+        Challenge::new_test(meta_a.clone(), 1000, 1, FieldElement::from(51u64)),
+        Challenge::new_test(meta_b.clone(), 1000, 1, FieldElement::from(62u64)),
+    ];
+
+    let system = kontor_crypto::api::PorSystem::new(&ledger);
+    let mut proof = system
+        .prove(vec![&prepared_a, &prepared_b], &challenges)
+        .expect("Should generate a valid multi-file proof");
+
+    proof.aggregated_tree_depth = usize::BITS as usize - 1;
+    let res = system.verify(&proof, &challenges);
+    assert!(
+        matches!(res, Err(KontorPoRError::InvalidLedgerRoot { .. })),
+        "Expected InvalidLedgerRoot for valid root paired with inflated depth, got: {res:?}"
     );
 }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -90,6 +90,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq 0.4.2",
 ]
 
 [[package]]
@@ -215,6 +238,18 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
@@ -465,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,22 +536,44 @@ dependencies = [
 
 [[package]]
 name = "kontor-crypto"
-version = "0.1.6"
+version = "0.3.0"
 dependencies = [
  "bincode",
+ "blake2b_simd",
  "clap",
+ "constant_time_eq 0.3.1",
  "ff",
  "generic-array 0.14.9",
+ "kontor-crypto-core",
+ "libc",
  "nova-snark",
+ "num-bigint 0.4.6",
  "once_cell",
  "rand",
- "reed-solomon-erasure",
  "serde",
+ "serde_json",
  "sha2",
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
+]
+
+[[package]]
+name = "kontor-crypto-core"
+version = "0.2.0"
+dependencies = [
+ "blake2b_simd",
+ "constant_time_eq 0.3.1",
+ "ff",
+ "generic-array 0.14.9",
+ "halo2curves",
+ "nova-snark",
+ "once_cell",
+ "reed-solomon-erasure",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -904,6 +967,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,3 +1366,9 @@ dependencies = [
  "quote",
  "syn 2.0.115",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/runexample.sh
+++ b/runexample.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")"
 echo "==> Building package (WASM + TypeScript)..."
 (cd packages/kontor-crypto && npm run build)
 
-echo "==> Starting server on http://localhost:4000"
-echo "    Open: http://localhost:4000/crates/kontor-crypto-wasm/examples/browser_prepare_file.html"
-npx serve . -l 4000
+echo "==> Starting server on http://127.0.0.1:4000"
+echo "    Open: http://127.0.0.1:4000/examples/browser_prepare_file.html"
+cd crates/kontor-crypto-wasm
+python3 -m http.server 4000 --bind 127.0.0.1

--- a/tools/picus/run-picus-docker.sh
+++ b/tools/picus/run-picus-docker.sh
@@ -2,28 +2,45 @@
 set -euo pipefail
 
 DOCKER_BIN="${DOCKER_BIN:-docker}"
-PICUS_DOCKER_IMAGE="${PICUS_DOCKER_IMAGE:-veridise/picus:base}"
+PICUS_DOCKER_IMAGE="${PICUS_DOCKER_IMAGE:-}"
 PICUS_DOCKER_PLATFORM="${PICUS_DOCKER_PLATFORM:-linux/amd64}"
 PICUS_DOCKER_MEMORY="${PICUS_DOCKER_MEMORY:-10g}"
 PICUS_DOCKER_WORKDIR="${PICUS_DOCKER_WORKDIR:-/workspace}"
+PICUS_DOCKER_ARTIFACTS_DIR="${PICUS_DOCKER_ARTIFACTS_DIR:-${PWD}/artifacts}"
 PICUS_DOCKER_CMD="${PICUS_DOCKER_CMD:-}"
 PICUS_SOURCE_DIR="${PICUS_SOURCE_DIR:-}"
+PICUS_ALLOW_MUTABLE_IMAGE="${PICUS_ALLOW_MUTABLE_IMAGE:-0}"
 
 if ! command -v "${DOCKER_BIN}" >/dev/null 2>&1; then
   echo "Missing docker binary: ${DOCKER_BIN}" >&2
   exit 127
 fi
 
+if [[ -z "${PICUS_DOCKER_IMAGE}" ]]; then
+  echo "PICUS_DOCKER_IMAGE must be set to a digest-pinned image reference, for example:" >&2
+  echo "  veridise/picus:base@sha256:fc396dbabd92cb0026a52dd3f2f72893374a1fc29367409cb49f251923089162" >&2
+  exit 64
+fi
+
+if [[ "${PICUS_DOCKER_IMAGE}" != *@sha256:* && "${PICUS_ALLOW_MUTABLE_IMAGE}" != "1" ]]; then
+  echo "Refusing mutable Picus image '${PICUS_DOCKER_IMAGE}'." >&2
+  echo "Use a digest-pinned image or set PICUS_ALLOW_MUTABLE_IMAGE=1 for local experiments." >&2
+  exit 64
+fi
+
+mkdir -p "${PICUS_DOCKER_ARTIFACTS_DIR}"
+
 DOCKER_ARGS=(
   run --rm
   --platform "${PICUS_DOCKER_PLATFORM}"
   --memory "${PICUS_DOCKER_MEMORY}"
-  -v "${PWD}:${PICUS_DOCKER_WORKDIR}"
+  -v "${PWD}:${PICUS_DOCKER_WORKDIR}:ro"
+  -v "${PICUS_DOCKER_ARTIFACTS_DIR}:${PICUS_DOCKER_WORKDIR}/artifacts"
   -w "${PICUS_DOCKER_WORKDIR}"
 )
 
 if [[ -n "${PICUS_SOURCE_DIR}" ]]; then
-  DOCKER_ARGS+=(-v "${PICUS_SOURCE_DIR}:/Picus")
+  DOCKER_ARGS+=(-v "${PICUS_SOURCE_DIR}:/Picus:ro")
 fi
 
 if [[ -z "${PICUS_DOCKER_CMD}" ]]; then


### PR DESCRIPTION
## Summary

Addresses the Codex Security scan findings on top of PR #50.

- Caps verifier challenge batch size before expensive planning or parameter loading.
- Bounds proof-supplied aggregation depth against ledger/root policy to prevent expensive parameter generation.
- Converts public field parsing helpers from panic-prone APIs to fallible validation.
- Requires digest-pinned Picus Docker images and read-only source mounts.
- Tightens release/demo/fuzz workflow hygiene around mutable npm installs, local serving, and fuzz lockfile checks.

## Root Cause

Several verifier and tooling paths trusted caller-controlled or environment-controlled inputs too early. In the verifier, oversized challenge batches and inflated proof depth could reach expensive code before cheap bounds checks. In tooling, mutable Docker image selection and broad writable mounts made local/CI Picus execution less reproducible than intended.

## Impact

The verifier now rejects malformed or oversized inputs before expensive work, ledger roots carry enough depth policy to validate accepted historical roots, parsing helpers return errors instead of panicking, and developer tooling has safer defaults.

## Validation

- `cargo check --workspace`
- `cargo test -p kontor-crypto-core`
- `cargo test -p kontor-crypto --test verifier_edge_cases -- --nocapture`
- `cargo test -p kontor-crypto --test stateless_verify -- --nocapture`
- `cargo test -p kontor-crypto ledger --lib -- --nocapture`
- `cargo metadata --manifest-path fuzz/Cargo.toml --locked --offline --format-version=1`
- `cargo check --manifest-path fuzz/Cargo.toml --locked --offline --tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo test --all-features --workspace`
- Pre-push hook: fmt, clippy, `cargo nextest run` with 314 passed / 5 skipped, and `cargo audit` with existing allowed RustSec warnings
